### PR TITLE
Include response data in http errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2019-22-07
+- Included response data in a http error (can allow clients to display server messages)
+
 ## [0.3.0] - 2019-24-06
 ### Added
 - Included response data in a decoding error (can allow clients to handle JSON fragments)

--- a/SCNetworkAPI.podspec
+++ b/SCNetworkAPI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SCNetworkAPI'
-  s.version          = '0.3.0'
+  s.version          = '0.4.0'
   s.summary          = 'Networking library.'
   s.description      = <<-DESC
 TODO: Add long description of the pod here.

--- a/SCNetworkAPI/Source/Error.swift
+++ b/SCNetworkAPI/Source/Error.swift
@@ -10,7 +10,7 @@ import Foundation
 public enum NetworkAPIError: Error {
     case codingError(String)
     case decodingError(Error, Data?)
-    case httpError(Int)
+    case httpError(Int, Data?)
     case malformedURL
     case requestFailed(Error)
     case wrongServer
@@ -25,7 +25,7 @@ extension NetworkAPIError: LocalizedError {
             return "Coding error: \(message)"
         case .decodingError(let error, _):
             return "Decoding error: \(error.localizedDescription)"
-        case .httpError(let statusCode):
+        case .httpError(let statusCode, _):
             return "HTTP status code: \(statusCode)"
         case .malformedURL:
             return "Malformed URL"

--- a/SCNetworkAPI/Source/SCNetworkAPI.swift
+++ b/SCNetworkAPI/Source/SCNetworkAPI.swift
@@ -87,7 +87,7 @@ open class NetworkAPI {
                 guard let response = response as? HTTPURLResponse else { fatalError("Casting response to HTTPURLResponse failed") }
 
                 guard 200...299 ~= response.statusCode else {
-                    throw NetworkAPIError.httpError(response.statusCode)
+                    throw NetworkAPIError.httpError(response.statusCode, data)
                 }
 
                 // Attempt to decode the response if we're expecting one

--- a/SCNetworkAPI/Supporting Files/Info.plist
+++ b/SCNetworkAPI/Supporting Files/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.4.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>


### PR DESCRIPTION
Hi @nbrooke, sometimes when we get a 400 error for example, the API we work with do contain some useful debugging message in the response data that we can then display in the app, which would be better than just simply "HTTP status code: 400"

Also bumped version to 0.4.0