### PR TITLE
Another attempt at handling expected errors.

### DIFF
--- a/Netable/Netable.xcodeproj/project.pbxproj
+++ b/Netable/Netable.xcodeproj/project.pbxproj
@@ -28,6 +28,13 @@
 		B8C928A523E9FC3E00DB2B37 /* URLRequest+Multipart.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C928A423E9FC3E00DB2B37 /* URLRequest+Multipart.swift */; };
 		B8C928A723E9FC8D00DB2B37 /* URLRequest+EncodeURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C928A623E9FC8D00DB2B37 /* URLRequest+EncodeURL.swift */; };
 		B8C928A923E9FDCC00DB2B37 /* Netable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C928A823E9FDCC00DB2B37 /* Netable.swift */; };
+		C602DFE924291D25005E3980 /* ExpectedErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C602DFE824291D25005E3980 /* ExpectedErrorResponse.swift */; };
+		C602DFED24291E23005E3980 /* Error404ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C602DFEC24291E23005E3980 /* Error404ViewController.swift */; };
+		C602DFEF24291ED7005E3980 /* Error404Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = C602DFEE24291ED7005E3980 /* Error404Request.swift */; };
+		C602DFF324292003005E3980 /* CustomLoggerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C602DFF024292003005E3980 /* CustomLoggerViewController.swift */; };
+		C602DFF424292003005E3980 /* EmptyLoggerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C602DFF124292003005E3980 /* EmptyLoggerViewController.swift */; };
+		C602DFF524292003005E3980 /* DecodeSnakeCaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C602DFF224292003005E3980 /* DecodeSnakeCaseViewController.swift */; };
+		C602DFF72429206D005E3980 /* SampleGETJSONDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C602DFF62429206D005E3980 /* SampleGETJSONDecoder.swift */; };
 		C64F8590241FE4670028E0E9 /* Netable.podspec in Resources */ = {isa = PBXBuildFile; fileRef = C64F858F241FE4670028E0E9 /* Netable.podspec */; };
 		C64F8592241FE4870028E0E9 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = C64F8591241FE4870028E0E9 /* CHANGELOG.md */; };
 		C64F8594241FE70E0028E0E9 /* ExamplesTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64F8593241FE70E0028E0E9 /* ExamplesTableViewController.swift */; };
@@ -92,6 +99,13 @@
 		B8C928A423E9FC3E00DB2B37 /* URLRequest+Multipart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Multipart.swift"; sourceTree = "<group>"; };
 		B8C928A623E9FC8D00DB2B37 /* URLRequest+EncodeURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+EncodeURL.swift"; sourceTree = "<group>"; };
 		B8C928A823E9FDCC00DB2B37 /* Netable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Netable.swift; sourceTree = "<group>"; };
+		C602DFE824291D25005E3980 /* ExpectedErrorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpectedErrorResponse.swift; sourceTree = "<group>"; };
+		C602DFEC24291E23005E3980 /* Error404ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error404ViewController.swift; sourceTree = "<group>"; };
+		C602DFEE24291ED7005E3980 /* Error404Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error404Request.swift; sourceTree = "<group>"; };
+		C602DFF024292003005E3980 /* CustomLoggerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomLoggerViewController.swift; sourceTree = "<group>"; };
+		C602DFF124292003005E3980 /* EmptyLoggerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyLoggerViewController.swift; sourceTree = "<group>"; };
+		C602DFF224292003005E3980 /* DecodeSnakeCaseViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecodeSnakeCaseViewController.swift; sourceTree = "<group>"; };
+		C602DFF62429206D005E3980 /* SampleGETJSONDecoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SampleGETJSONDecoder.swift; sourceTree = "<group>"; };
 		C64F858F241FE4670028E0E9 /* Netable.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Netable.podspec; path = ../../Netable.podspec; sourceTree = "<group>"; };
 		C64F8591241FE4870028E0E9 /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = CHANGELOG.md; path = ../../CHANGELOG.md; sourceTree = "<group>"; };
 		C64F8593241FE70E0028E0E9 /* ExamplesTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamplesTableViewController.swift; sourceTree = "<group>"; };
@@ -178,6 +192,7 @@
 				B8C9289A23E9F97B00DB2B37 /* Notification.swift */,
 				B8C9288423E9F68000DB2B37 /* Info.plist */,
 				C6953F41241A95830044D278 /* LogDestination.swift */,
+				C602DFE824291D25005E3980 /* ExpectedErrorResponse.swift */,
 			);
 			path = Netable;
 			sourceTree = "<group>";
@@ -207,6 +222,8 @@
 		C64F8596241FED3F0028E0E9 /* Requests */ = {
 			isa = PBXGroup;
 			children = (
+				C602DFF62429206D005E3980 /* SampleGETJSONDecoder.swift */,
+				C602DFEE24291ED7005E3980 /* Error404Request.swift */,
 				B822C8FF23F210D800D7BDAD /* GetCatRequest.swift */,
 				C64F859B241FF09D0028E0E9 /* LoginRequest.swift */,
 			);
@@ -224,9 +241,13 @@
 		C64F8598241FED6C0028E0E9 /* View Controllers */ = {
 			isa = PBXGroup;
 			children = (
-				B822C8F123F20E8900D7BDAD /* SampleGetViewController.swift */,
+				C602DFF024292003005E3980 /* CustomLoggerViewController.swift */,
+				C602DFF224292003005E3980 /* DecodeSnakeCaseViewController.swift */,
+				C602DFF124292003005E3980 /* EmptyLoggerViewController.swift */,
+				C602DFEC24291E23005E3980 /* Error404ViewController.swift */,
 				C64F8593241FE70E0028E0E9 /* ExamplesTableViewController.swift */,
 				C64F859D241FF8E60028E0E9 /* PostLoginViewController.swift */,
+				B822C8F123F20E8900D7BDAD /* SampleGetViewController.swift */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -389,11 +410,17 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C602DFF424292003005E3980 /* EmptyLoggerViewController.swift in Sources */,
+				C602DFF72429206D005E3980 /* SampleGETJSONDecoder.swift in Sources */,
 				C66901AF241C1B0A002954C5 /* CustomLogDestination.swift in Sources */,
+				C602DFEF24291ED7005E3980 /* Error404Request.swift in Sources */,
 				B822C90023F210D800D7BDAD /* GetCatRequest.swift in Sources */,
 				C64F8594241FE70E0028E0E9 /* ExamplesTableViewController.swift in Sources */,
+				C602DFED24291E23005E3980 /* Error404ViewController.swift in Sources */,
 				B822C8F223F20E8900D7BDAD /* SampleGetViewController.swift in Sources */,
 				B822C8EE23F20E8900D7BDAD /* AppDelegate.swift in Sources */,
+				C602DFF524292003005E3980 /* DecodeSnakeCaseViewController.swift in Sources */,
+				C602DFF324292003005E3980 /* CustomLoggerViewController.swift in Sources */,
 				C64F859C241FF09D0028E0E9 /* LoginRequest.swift in Sources */,
 				C64F859E241FF8E60028E0E9 /* PostLoginViewController.swift in Sources */,
 				B822C8F023F20E8900D7BDAD /* SceneDelegate.swift in Sources */,
@@ -409,6 +436,7 @@
 				B8C9289F23E9FB1500DB2B37 /* URLRequest+EncodeParameters.swift in Sources */,
 				B8C928A123E9FBA100DB2B37 /* Request.swift in Sources */,
 				C6953F42241A95830044D278 /* LogDestination.swift in Sources */,
+				C602DFE924291D25005E3980 /* ExpectedErrorResponse.swift in Sources */,
 				B8C9289D23E9FA0E00DB2B37 /* Error.swift in Sources */,
 				B8C928A323E9FBEC00DB2B37 /* HTTPMethod.swift in Sources */,
 				B8C9289B23E9F97B00DB2B37 /* Notification.swift in Sources */,

--- a/Netable/Netable/ExpectedErrorResponse.swift
+++ b/Netable/Netable/ExpectedErrorResponse.swift
@@ -1,0 +1,19 @@
+//
+//  ExpectedErrorResponse.swift
+//  Netable
+//
+//  Created by Brendan on 2020-03-23.
+//  Copyright © 2020 Steamclock Software. All rights reserved.
+//
+
+import Foundation
+
+public struct ExpectedErrorResponse {
+    var code: Int
+    var handler: (Data?) -> Void
+
+    public init(code: Int, handler: @escaping ((Data?) -> Void)) {
+        self.code = code
+        self.handler = handler
+    }
+}

--- a/Netable/Netable/Request.swift
+++ b/Netable/Netable/Request.swift
@@ -16,6 +16,7 @@ public protocol Request {
     var path: String { get }
     var parameters: Parameters { get }
     var jsonKeyDecodingStrategy: JSONDecoder.KeyDecodingStrategy { get }
+    var expectedErrorResponses: [ExpectedErrorResponse] { get }
 
     func finalize(raw: RawResource) -> Result<FinalResource, NetableError>
 }
@@ -23,6 +24,10 @@ public protocol Request {
 public extension Request {
     var jsonKeyDecodingStrategy: JSONDecoder.KeyDecodingStrategy {
         return .useDefaultKeys
+    }
+
+    var expectedErrorResponses: [ExpectedErrorResponse] {
+        return [ExpectedErrorResponse]()
     }
 }
 

--- a/Netable/NetableExample/Requests/Error404Request.swift
+++ b/Netable/NetableExample/Requests/Error404Request.swift
@@ -1,0 +1,22 @@
+//
+//  Error404Request.swift
+//  NetableExample
+//
+//  Created by Brendan on 2020-03-23.
+//  Copyright © 2020 Steamclock Software. All rights reserved.
+//
+
+import Netable
+
+struct Error404Request: Request {
+    typealias Parameters = Empty
+    typealias RawResource = Empty
+
+    public var method: HTTPMethod { return .get }
+
+    public var path: String {
+        return "/1a2a3a"
+    }
+
+    public var expectedErrorResponses: [ExpectedErrorResponse]
+}

--- a/Netable/NetableExample/Resources/Base.lproj/Main.storyboard
+++ b/Netable/NetableExample/Resources/Base.lproj/Main.storyboard
@@ -67,6 +67,37 @@
             </objects>
             <point key="canvasLocation" x="1479.7101449275362" y="-81.026785714285708"/>
         </scene>
+        <!--Error404 View Controller-->
+        <scene sceneID="yoH-RX-N6v">
+            <objects>
+                <viewController storyboardIdentifier="Error404ViewController" id="0Ag-uX-3Xr" customClass="Error404ViewController" customModule="NetableExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="MRe-7q-05G">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ocB-1R-j1m">
+                                <rect key="frame" x="50" y="438" width="314" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="ocB-1R-j1m" firstAttribute="centerY" secondItem="MRe-7q-05G" secondAttribute="centerY" id="5yb-W7-XlR"/>
+                            <constraint firstItem="ocB-1R-j1m" firstAttribute="leading" secondItem="9un-93-43H" secondAttribute="leading" constant="50" id="cJy-PH-Ib0"/>
+                            <constraint firstItem="9un-93-43H" firstAttribute="trailing" secondItem="ocB-1R-j1m" secondAttribute="trailing" constant="50" id="gnU-B8-fgr"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="9un-93-43H"/>
+                    </view>
+                    <connections>
+                        <outlet property="errorLabel" destination="ocB-1R-j1m" id="wf8-h9-zLU"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="wHp-aZ-7LZ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2241" y="-85"/>
+        </scene>
         <!--POST Login-->
         <scene sceneID="bXm-Mi-ql1">
             <objects>

--- a/Netable/NetableExample/View Controllers/Error404ViewController.swift
+++ b/Netable/NetableExample/View Controllers/Error404ViewController.swift
@@ -1,0 +1,49 @@
+//
+//  Error404ViewController.swift
+//  NetableExample
+//
+//  Created by Brendan on 2020-03-23.
+//  Copyright © 2020 Steamclock Software. All rights reserved.
+//
+
+import Netable
+import UIKit
+
+class Error404ViewController: UIViewController {
+    @IBOutlet weak var errorLabel: UILabel!
+
+    // Create a Netable instance that won't record logs to anywhere
+    private let netable = Netable(baseURL: URL(string: "https://api.thecatapi.com/1a2a3a/")!, logDestination: EmptyLogDestination())
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+
+        let errorRequest = Error404Request(expectedErrorResponses: [
+            ExpectedErrorResponse(code: 404) { [weak self] data in
+                if let data = data,
+                        let dataString = String(data: data, encoding: .utf8) {
+                    self?.errorLabel.text = dataString
+                }
+            }
+        ])
+
+        netable.request(errorRequest) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success:
+                break
+            case .failure(let error):
+                let alert = UIAlertController(
+                    title: "Uh oh!",
+                    message: "Request failed with error: \(error)",
+                    preferredStyle: .alert
+                )
+
+                alert.addAction(UIAlertAction(title: "OK", style: .cancel))
+                self.present(alert, animated: true, completion: nil)
+            }
+        }
+    }
+}

--- a/Netable/NetableExample/View Controllers/ExamplesTableViewController.swift
+++ b/Netable/NetableExample/View Controllers/ExamplesTableViewController.swift
@@ -26,8 +26,8 @@ class ExamplesTableViewController: UITableViewController {
                 RequestRow(title: "GET Cat Image", vcIdentifier: "SampleGetViewController"),
                 RequestRow(title: "Custom Logger Example", vcIdentifier: "CustomLoggerViewController"),
                 RequestRow(title: "Empty Logger Example", vcIdentifier: "EmptyLoggerViewController"),
-                RequestRow(title: "Decode_snake_case", vcIdentifier: "DecodeSnakeCaseViewController")
-
+                RequestRow(title: "Decode_snake_case", vcIdentifier: "DecodeSnakeCaseViewController"),
+                RequestRow(title: "Handle Expected Error", vcIdentifier: "Error404ViewController")
             ]
         ),
         RequestSet(sectionTitle: "POST", requestRows: [RequestRow(title: "POST Sample Login", vcIdentifier: "PostLoginViewController")]),


### PR DESCRIPTION
Continuing the discussion from #47.

Adds a new optional field to `Request`, `public var expectedErrorResponses: [ExpectedErrorResponse]`

```
public struct ExpectedErrorResponse {
    var code: Int
    var handler: (Data?) -> Void
}
```

This is also a little clunky, but you end up declaring your expected error response handlers in the `Request` constructor.

Thoughts? @nbrooke 