### PR TITLE
Improve support for redaction in Netable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.8.6] - UNRELEASED
+### Changed
+- Changed multi-line logs that weren't printing to the console properly to single liners.
+- Changed `LogEvent.message` to accept a `StaticString` instead of a `String`.
+
 ## [0.8.5] - 2020-05-01
 ### Added
 - Added a new post example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [0.8.6] - UNRELEASED
+### Added
+- Added `LogEvent.startupInfo`  to keep track of some debugging info while booting.
+
 ### Changed
 - Changed multi-line logs that weren't printing to the console properly to single liners.
 - Changed `LogEvent.message` to accept a `StaticString` instead of a `String`.

--- a/Netable.podspec
+++ b/Netable.podspec
@@ -1,6 +1,6 @@
  Pod::Spec.new do |s|
   s.name             = 'Netable'
-  s.version          = '0.8.5'
+  s.version          = '0.8.6'
   s.summary          = 'A simple and swifty networking library.'
   s.description      = 'Netable is a simple Swift framework for working with both simple and non-REST-compliant HTTP endpoints.'
   s.homepage         = 'https://github.com/steamclock/netable/'

--- a/Netable/Netable.xcodeproj/project.pbxproj
+++ b/Netable/Netable.xcodeproj/project.pbxproj
@@ -674,7 +674,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.8.5;
+				MARKETING_VERSION = 0.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.Netable;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -704,7 +704,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.8.5;
+				MARKETING_VERSION = 0.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.Netable;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/Netable/Netable/LogDestination.swift
+++ b/Netable/Netable/LogDestination.swift
@@ -10,6 +10,10 @@ import Foundation
 
 /// Wrapper class for log events emitted by Netable.
 public enum LogEvent: CustomDebugStringConvertible {
+
+    /// Print up some debugging info at start.
+    case startupInfo(baseURL: URL, logDestination: LogDestination)
+
     /// A generic message, not tied to request state.
     case message(StaticString)
 
@@ -25,7 +29,10 @@ public enum LogEvent: CustomDebugStringConvertible {
     /// Default overrides, used by the default logging destination.
     public var debugDescription: String {
         switch self {
-        case .message(let message): return message.description
+        case .startupInfo(let baseURL, let logDestination):
+            return "Netable instance initiated. Here we go! Base URL: \(baseURL.absoluteString). Log Destination: \(logDestination)"
+        case .message(let message):
+            return message.description
         case .requestStarted(let urlString, let method, let headers, let params):
             return "Started \(method.rawValue) request... URL: \(urlString) Headers: \(headers) Params: \(params ?? [:])"
         case .requestCompleted(let statusCode, let responseData, let finalizedResult):

--- a/Netable/Netable/LogDestination.swift
+++ b/Netable/Netable/LogDestination.swift
@@ -11,7 +11,7 @@ import Foundation
 /// Wrapper class for log events emitted by Netable.
 public enum LogEvent: CustomDebugStringConvertible {
     /// A generic message, not tied to request state.
-    case message(String)
+    case message(StaticString)
 
     /// Request has been successfully initiated.
     case requestStarted(urlString: String, method: HTTPMethod, headers: [String: Any], params: [String: Any]?)
@@ -25,20 +25,11 @@ public enum LogEvent: CustomDebugStringConvertible {
     /// Default overrides, used by the default logging destination.
     public var debugDescription: String {
         switch self {
-        case .message(let message): return message
+        case .message(let message): return message.description
         case .requestStarted(let urlString, let method, let headers, let params):
-            return """
-                Started \(method.rawValue) request...
-                    URL: \(urlString)
-                    Headers: \(headers)
-                    Params: \(params ?? [:])
-            """
+            return "Started \(method.rawValue) request... URL: \(urlString) Headers: \(headers) Params: \(params ?? [:])"
         case .requestCompleted(let statusCode, let responseData, let finalizedResult):
-            return """
-                Request completed with status code \(statusCode)
-                    Data: \(responseData ?? Data())
-                    Finalized data: \(String(describing: finalizedResult))
-            """
+            return "Request completed with status code \(statusCode) Data: \(responseData ?? Data()) Finalized data: \(String(describing: finalizedResult))"
         case .requestFailed(let error):
             return "Request failed: \(error.localizedDescription)"
         }

--- a/Netable/Netable/Netable.swift
+++ b/Netable/Netable/Netable.swift
@@ -33,7 +33,7 @@ open class Netable {
         self.urlSession = URLSession(configuration: configuration)
         self.logDestination = logDestination
 
-        logDestination.log(event: .message("Netable instance initiated. Here we go!"))
+        logDestination.log(event: .startupInfo(baseURL: baseURL, logDestination: logDestination))
     }
 
     /**

--- a/Netable/Netable/Netable.swift
+++ b/Netable/Netable/Netable.swift
@@ -56,6 +56,11 @@ open class Netable {
             urlRequest = URLRequest(url: finalURL)
             urlRequest.httpMethod = request.method.rawValue
 
+            guard finalURL.scheme == "https" || finalURL.scheme == "http" else {
+                self.logDestination.log(event: .message("Only HTTP and HTTPS request are supported currently."))
+                throw NetableError.malformedURL
+            }
+
             if T.Parameters.self != Empty.self {
                 try urlRequest.encodeParameters(for: request)
             }
@@ -107,7 +112,7 @@ open class Netable {
                     throw NetableError.requestFailed(error)
                 }
 
-                guard let response = response as? HTTPURLResponse else { throw NetableError.codingError("Casting response to HTTPURLResponse failed") }
+                guard let response = response as? HTTPURLResponse else { fatalError("Casting response to HTTPURLResponse failed") }
                 guard 200...299 ~= response.statusCode else {
                     self.logDestination.log(event: .requestCompleted(statusCode: response.statusCode, responseData: data, finalizedResult: nil))
                     throw NetableError.httpError(response.statusCode, data)

--- a/Netable/Netable/Netable.swift
+++ b/Netable/Netable/Netable.swift
@@ -33,11 +33,7 @@ open class Netable {
         self.urlSession = URLSession(configuration: configuration)
         self.logDestination = logDestination
 
-        logDestination.log(event: .message("""
-            Netable instance initiated. Here we go!
-                Base URL: Base URL: \(baseURL.absoluteString)
-                Log Destination: \(logDestination)
-        """))
+        logDestination.log(event: .message("Netable instance initiated. Here we go!"))
     }
 
     /**
@@ -111,7 +107,7 @@ open class Netable {
                     throw NetableError.requestFailed(error)
                 }
 
-                guard let response = response as? HTTPURLResponse else { fatalError("Casting response to HTTPURLResponse failed") }
+                guard let response = response as? HTTPURLResponse else { throw NetableError.codingError("Casting response to HTTPURLResponse failed") }
                 guard 200...299 ~= response.statusCode else {
                     self.logDestination.log(event: .requestCompleted(statusCode: response.statusCode, responseData: data, finalizedResult: nil))
                     throw NetableError.httpError(response.statusCode, data)
@@ -151,7 +147,7 @@ open class Netable {
           fatalError("Attempted to cancel a task from a different Netable session")
         }
 
-        self.logDestination.log(event: .message("Cancelling request with taskIdentifier: \(taskId)"))
+        self.logDestination.log(event: .message("Request cancelled by task identifier."))
         urlSession.getAllTasks { tasks in
             guard let task = tasks.first(where: { $0.taskIdentifier == taskId.id }) else {
                 self.logDestination.log(event: .message("Failed to cancel request, no request with that id was found."))
@@ -167,7 +163,7 @@ open class Netable {
      */
     open func cancelAllTasks() {
         urlSession.getAllTasks { tasks in
-            self.logDestination.log(event: .message("Cancelling all \(tasks.count) ongoing tasks."))
+            self.logDestination.log(event: .message("Cancelling all ongoing tasks."))
             for task in tasks {
                 task.cancel()
             }

--- a/Netable/Netable/Netable.swift
+++ b/Netable/Netable/Netable.swift
@@ -56,7 +56,7 @@ open class Netable {
             urlRequest = URLRequest(url: finalURL)
             urlRequest.httpMethod = request.method.rawValue
 
-            guard finalURL.scheme == "https" || finalURL.scheme == "http" else {
+            guard finalURL.scheme?.lowercased() == "https" || finalURL.scheme?.lowercased() == "http" else {
                 self.logDestination.log(event: .message("Only HTTP and HTTPS request are supported currently."))
                 throw NetableError.malformedURL
             }


### PR DESCRIPTION
Fixes #21 

While we decided that Netable shouldn't actually handle redaction itself, it should certainly make it easy for people to implement their own redaction.

Nigel outlined some things that would be required for this [in Slack](https://steamclock.slack.com/archives/CTJM6EV6Z/p1589574843016200):
- We never print anything except through the LogEvent / LogDestination interfaces.
- The .message event never contains any sensitive data (We should maybe see if we can make .message take a StaticString, in order to guarantee that it’s impossible to leak data through it.
- Anything that might want to be redacted gets it’s own LogEvent case, and is using a structured data (an object or dictionary) to represent it rather than raw strings

To address these I:
- Made sure we aren't printing anything except thru LogEvent
- Changed .message to accept only `StaticStrings`.
- Added a new `LogEvent.startupInfo` to print the dynamic info we might want to know for debugging at startup
- Made sure anything we may want to redact has its own log event

I also fixed a place where we were throwing a `fatalError` that should throw an error the client can handle, and fixed the formatting on some multi-line messages that don't print properly.