### PR TITLE
fix nested params failing for all post requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Changed multi-line logs that weren't printing to the console properly to single liners.
 - Changed `LogEvent.message` to accept a `StaticString` instead of a `String`.
+- Changed when parameters are checked for nested objects.
 
 ## [0.8.5] - 2020-05-01
 ### Added

--- a/Netable/Netable/URLRequest+EncodeParameters.swift
+++ b/Netable/Netable/URLRequest+EncodeParameters.swift
@@ -75,12 +75,10 @@ extension URLRequest {
             }
         case .post:
             do {
-                let paramsDictionary = try request.parameters.toParameterDictionary()
-
                 if request is MultipartFormData {
-                    try setMultipartFormData(paramsDictionary, encoding: .utf8)
+                    try setMultipartFormData(try request.parameters.toParameterDictionary(), encoding: .utf8)
                 } else if request is UrlEncodedFormData {
-                    setUrlEncodedFormData(paramsDictionary)
+                    setUrlEncodedFormData(try request.parameters.toParameterDictionary())
                 } else {
                     fallthrough
                 }


### PR DESCRIPTION
This came up while getting some prototypes set up for Ora, right now we're not able to encode nested params for POST requests at all. More discussion [here](https://steamclock.slack.com/archives/C014LP527KK/p1591992024103100)