### PR TITLE
Fix build on Android / Linux ( / Windows?)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 24-06-20
+### Changed
+- Fixed build on non-Apple platforms (note: only basic compliation has been tested, still might not work properly)
+- Use TimeInterval instead of CFTimeInterval in public interface (shouldn't actually change API, since they are both just Double typedefs)
+- Remove not-publically-exposed-and-probably-not-working capability to use encodings other than UTF8 for multipart form requests.
+
 ## [0.9.0] - 19-06-20
 ### Added
 - Added `jsonKeyEncodingStrategy` to `Request`s, allowing custom encoding strategies for request params.

--- a/Netable.podspec
+++ b/Netable.podspec
@@ -1,6 +1,6 @@
  Pod::Spec.new do |s|
   s.name             = 'Netable'
-  s.version          = '0.9.0'
+  s.version          = '0.9.1'
   s.summary          = 'A simple and swifty networking library.'
   s.description      = 'Netable is a simple Swift framework for working with both simple and non-REST-compliant HTTP endpoints.'
   s.homepage         = 'https://github.com/steamclock/netable/'

--- a/Netable/Netable/Netable.swift
+++ b/Netable/Netable/Netable.swift
@@ -7,7 +7,16 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+#if canImport(QuartzCore)
 import QuartzCore
+#else
+func CACurrentMediaTime() -> TimeInterval {
+    return Date.timeIntervalSinceReferenceDate
+}
+#endif
 
 open class Netable {
     /// The URL session requests are run through.

--- a/Netable/Netable/Notification.swift
+++ b/Netable/Netable/Notification.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 extension Notification.Name {
     public static let NetableRequestDidComplete = Notification.Name(rawValue: "com.steamclock.netable.notification.name.requestDidComplete")
@@ -33,7 +36,7 @@ class NetableNotification {
      *
      * - returns: The user info encoded as a `Dictionary<String, Any>`
      */
-    static func userInfo(forRequest request: URLRequest?, data: Data?, response: URLResponse?, duration: CFTimeInterval?, error: Swift.Error?) -> [String: Any] {
+    static func userInfo(forRequest request: URLRequest?, data: Data?, response: URLResponse?, duration: TimeInterval?, error: Swift.Error?) -> [String: Any] {
         var userInfo: [String: Any] = [:]
 
         if let request = request {

--- a/Netable/Netable/URLRequest+EncodeParameters.swift
+++ b/Netable/Netable/URLRequest+EncodeParameters.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 extension Encodable {
     /**
@@ -80,7 +83,7 @@ extension URLRequest {
         case .post:
             do {
                 if request is MultipartFormData {
-                    try setMultipartFormData(try request.parameters.toParameterDictionary(encodingStrategy: request.jsonKeyEncodingStrategy), encoding: .utf8)
+                    try setMultipartFormData(try request.parameters.toParameterDictionary(encodingStrategy: request.jsonKeyEncodingStrategy))
                 } else if request is UrlEncodedFormData {
                     setUrlEncodedFormData(try request.parameters.toParameterDictionary(encodingStrategy: request.jsonKeyEncodingStrategy))
                 } else {

--- a/Netable/Netable/URLRequest+EncodeURL.swift
+++ b/Netable/Netable/URLRequest+EncodeURL.swift
@@ -9,6 +9,9 @@
 import Foundation
 
 public protocol UrlEncodedFormData { }
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 extension URLRequest {
     /**


### PR DESCRIPTION
Netable only really depends on Foundation, so there's no reason it shouldn't be able to build on non-Apple platform.

This PR SHOULD enable it to build and work on any platform by:
 - Adding the `FoundationNetworking` dependancy that's required on non-Apple platforms (https://forums.swift.org/t/foundationnetworking/24769/25)
 - Switching `CFTimeInterval` (which is not available on other platforms) with `TimeInterval` in the public interface
 - Replacing us of `CACurrentMediaTime` with plain old `Date.timeintervalSinceReferenceDate` when building on a non-Apple platform.
 - Remove the use of `CFStringConvertEncodingToIANACharSetName` (not available other platforms) and just always using UTF8 encoding for multi-part form requests (Doesn't seem useful to support that, it wasn't publicly exposed, and I'm not sure other encoding would have worked properly anyway with the code as it was)

Note: I have only tested BUILDING using another toolchain so far (Android in my case), issues further downstream in my test project still prevent actually linking a final app with it, so I can't guarantee that it works yet.

Side note: I noticed that the versions are currently inconsistent between CocoaPods and Swift Package Manager (Cocoapods is up to 0.9.0, and there was also an 0.8.6 Cocoapods release, but the latest SPM release is 0.8.5), when I merge this, I can either tag it as the 0.9.0 SPM release (which seems simpler, the mild code difference shouldn't affect things, since the code changes are mostly related to non-Apple platforms which aren't an issue for Cocoapods), or bump the Cocoapods version to 0.9.1 and tag for SPM the same. 