### PR TITLE
Fix successful request log event not correctly printing finalized data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.10.3] - 12-01-21
+### Changed
+- Fixed an issue with logging successful requests that was preventing finalized data from being printed properly.
+- Fixed a couple small tpyos.
+
 ## [0.10.2] - 10-08-20
 ### Added
 - Added support for `DELETE` requests.

--- a/Netable.podspec
+++ b/Netable.podspec
@@ -1,12 +1,12 @@
  Pod::Spec.new do |s|
   s.name             = 'Netable'
-  s.version          = '0.10.2'
+  s.version          = '0.10.3'
   s.summary          = 'A simple and swifty networking library.'
   s.description      = 'Netable is a simple Swift framework for working with both simple and non-REST-compliant HTTP endpoints.'
   s.homepage         = 'https://github.com/steamclock/netable/'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Brendan Lensink' => 'brendan@steamclock.com' }
-  s.source           = { :git => 'https://github.com/steamclock/netable.git', :tag => 'v0.10.2' }
+  s.source           = { :git => 'https://github.com/steamclock/netable.git', :tag => 'v0.10.3' }
   s.ios.deployment_target = '11.0'
   s.osx.deployment_target  = '10.14'
   s.source_files = 'Netable/Netable/*.{swift,h,m}'

--- a/Netable/Netable.xcodeproj/project.pbxproj
+++ b/Netable/Netable.xcodeproj/project.pbxproj
@@ -686,7 +686,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.10.2;
+				MARKETING_VERSION = 0.10.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.Netable;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -716,7 +716,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.10.2;
+				MARKETING_VERSION = 0.10.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.Netable;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/Netable/Netable/LogDestination.swift
+++ b/Netable/Netable/LogDestination.swift
@@ -29,9 +29,9 @@ public enum LogEvent: CustomDebugStringConvertible {
     /// Request has been successfully initiated.
     case requestStarted(request: RequestInfo)
 
-    /// Request has sucessfully completed. 
+    /// Request has successfully completed.
     /// Note: taskTime only covers the time it took the current network request to run, in retry scenarios the time for the whole request may be longer.
-    case requestSuccess(request: RequestInfo, taskTime: TimeInterval, statusCode: Int, responseData: Data?, finalizedResult: Any?)
+    case requestSuccess(request: RequestInfo, taskTime: TimeInterval, statusCode: Int, responseData: Data?, finalizedResult: Any)
 
     /// Sent when a request fails but will be retried. Note: taskTime only cover the time it took the current network request to run, in retry scenarios the time for the whole request may be longer.
     case requestRetrying(request: RequestInfo, taskTime: TimeInterval, error: NetableError)

--- a/Netable/Netable/Netable.swift
+++ b/Netable/Netable/Netable.swift
@@ -125,7 +125,14 @@ open class Netable {
                 switch decoded {
                 case .success(let raw):
                     let finalizedData = request.finalize(raw: raw)
-                    self.log(.requestSuccess(request: requestInfo, taskTime: time, statusCode: response.statusCode, responseData: data, finalizedResult: finalizedData))
+
+                    switch finalizedData {
+                    case .success(let finalizedResult):
+                        self.log(.requestSuccess(request: requestInfo, taskTime: time, statusCode: response.statusCode, responseData: data, finalizedResult: finalizedResult))
+                    case .failure(let error):
+                        self.log(.requestFailed(request: requestInfo, taskTime: time, error: error))
+                    }
+
                     completion(finalizedData)
                 case .failure(let error):
                     throw error

--- a/Netable/Netable/Netable.swift
+++ b/Netable/Netable/Netable.swift
@@ -129,7 +129,7 @@ open class Netable {
                     if case let .success(finalizedResult) = finalizedData {
                         self.log(.requestSuccess(request: requestInfo, taskTime: time, statusCode: response.statusCode, responseData: data, finalizedResult: finalizedResult))
                     } else if case let .failure(finalizedError) = finalizedData {
-                        throw NetableError.decodingError(finalizedError, data)
+                        throw finalizedError
                     } else {
                         throw NetableError.resourceExtractionError("Failed to parse the result of `Finalize`.")
                     }

--- a/Netable/Netable/Netable.swift
+++ b/Netable/Netable/Netable.swift
@@ -126,11 +126,12 @@ open class Netable {
                 case .success(let raw):
                     let finalizedData = request.finalize(raw: raw)
 
-                    switch finalizedData {
-                    case .success(let finalizedResult):
+                    if case let .success(finalizedResult) = finalizedData {
                         self.log(.requestSuccess(request: requestInfo, taskTime: time, statusCode: response.statusCode, responseData: data, finalizedResult: finalizedResult))
-                    case .failure(let error):
-                        self.log(.requestFailed(request: requestInfo, taskTime: time, error: error))
+                    } else if case let .failure(finalizedError) = finalizedData {
+                        throw NetableError.decodingError(finalizedError, data)
+                    } else {
+                        throw NetableError.resourceExtractionError("Failed to parse the result of `Finalize`.")
                     }
 
                     completion(finalizedData)

--- a/Netable/Netable/Netable.swift
+++ b/Netable/Netable/Netable.swift
@@ -126,12 +126,11 @@ open class Netable {
                 case .success(let raw):
                     let finalizedData = request.finalize(raw: raw)
 
-                    if case let .success(finalizedResult) = finalizedData {
+                    switch finalizedData {
+                    case .success(let finalizedResult):
                         self.log(.requestSuccess(request: requestInfo, taskTime: time, statusCode: response.statusCode, responseData: data, finalizedResult: finalizedResult))
-                    } else if case let .failure(finalizedError) = finalizedData {
+                    case .failure(let finalizedError):
                         throw finalizedError
-                    } else {
-                        throw NetableError.resourceExtractionError("Failed to parse the result of `Finalize`.")
                     }
 
                     completion(finalizedData)


### PR DESCRIPTION
`LogEvent.requestSuccess` expects `finalizedResult: Any`, but we were passing in `Result<Any, NetableError>` which was causing problems when we were trying to unwrap and print the finalized result.

I think there might be a more elegant way to do this, where we pass the whole result into `.requestSuccess` and then print a different message depending on whether the decoding was a success or not, because I think you could make an argument the request has succeeded either way, but I couldn't get it to work and I'm not sure it's worth dwelling on.