### PR TITLE
Log request bodies as separate logs, add some basic redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+- [60] Add better handling for printing request bodies to the console, including some default redaction for sensitive parameters.
+
 ## [0.10.3] - 12-01-21
 ### Changed
 - Fixed an issue with logging successful requests that was preventing finalized data from being printed properly.

--- a/Netable.podspec
+++ b/Netable.podspec
@@ -1,12 +1,12 @@
  Pod::Spec.new do |s|
   s.name             = 'Netable'
-  s.version          = '0.10.3'
+  s.version          = '1.0'
   s.summary          = 'A simple and swifty networking library.'
   s.description      = 'Netable is a simple Swift framework for working with both simple and non-REST-compliant HTTP endpoints.'
   s.homepage         = 'https://github.com/steamclock/netable/'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Brendan Lensink' => 'brendan@steamclock.com' }
-  s.source           = { :git => 'https://github.com/steamclock/netable.git', :tag => 'v0.10.3' }
+  s.source           = { :git => 'https://github.com/steamclock/netable.git', :tag => 'v1.0' }
   s.ios.deployment_target = '11.0'
   s.osx.deployment_target  = '10.14'
   s.source_files = 'Netable/Netable/*.{swift,h,m}'

--- a/Netable/Netable.xcodeproj/project.pbxproj
+++ b/Netable/Netable.xcodeproj/project.pbxproj
@@ -686,7 +686,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.10.3;
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.Netable;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -716,7 +716,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.10.3;
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.Netable;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/Netable/Netable/Config.swift
+++ b/Netable/Netable/Config.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 public struct Config {
-    var disableLogRedaction: Bool
+    var enableLogRedaction: Bool
     var timeout: TimeInterval?
 
-    public init(disableLogRedaction: Bool = false, timeout: TimeInterval? = nil) {
-        self.disableLogRedaction = disableLogRedaction
+    public init(enableLogRedaction: Bool = true, timeout: TimeInterval? = nil) {
+        self.enableLogRedaction = enableLogRedaction
         self.timeout = timeout
     }
 }

--- a/Netable/Netable/LogDestination.swift
+++ b/Netable/Netable/LogDestination.swift
@@ -14,7 +14,6 @@ public enum LogEvent: CustomDebugStringConvertible {
         public let urlString: String
         public let method: HTTPMethod
         public let headers: [String: Any]
-        public let params: [String: Any]?
     }
 
     /// Print up some debugging info at start.
@@ -28,6 +27,9 @@ public enum LogEvent: CustomDebugStringConvertible {
 
     /// Request has been successfully initiated.
     case requestStarted(request: RequestInfo)
+
+    /// Request body that is sent to the server.
+    case requestBody(body: [String: String])
 
     /// Request has successfully completed.
     /// Note: taskTime only covers the time it took the current network request to run, in retry scenarios the time for the whole request may be longer.
@@ -49,7 +51,9 @@ public enum LogEvent: CustomDebugStringConvertible {
         case .requestCreationFailed(let urlString, let error):
             return "Request (\(urlString)) failed: \(error.localizedDescription)"
         case .requestStarted(let request):
-            return "Started \(request.method.rawValue) request... URL: \(request.urlString) Headers: \(request.headers) Params: \(request.params ?? [:])"
+            return "Started \(request.method.rawValue) request... URL: \(request.urlString) Headers: \(request.headers)"
+        case .requestBody(let body):
+            return "Body: \(body)"
         case .requestSuccess(let request, _, let statusCode, let responseData, let finalizedResult):
             return "Request (\(request.urlString)) completed with status code \(statusCode) Data: \(responseData ?? Data()) Finalized data: \(String(describing: finalizedResult))"
         case .requestRetrying(let request, _, let error):

--- a/Netable/Netable/Netable.swift
+++ b/Netable/Netable/Netable.swift
@@ -114,7 +114,7 @@ open class Netable {
         )
 
         log(.requestStarted(request: requestInfo))
-        if config.disableLogRedaction, let params = try? request.parameters.toParameterDictionary(encodingStrategy: request.jsonKeyEncodingStrategy) {
+        if !config.enableLogRedaction, let params = try? request.parameters.toParameterDictionary(encodingStrategy: request.jsonKeyEncodingStrategy) {
             log(.requestBody(body: params))
         } else {
             log(.requestBody(body: request.unredactedParameters))

--- a/Netable/Netable/Netable.swift
+++ b/Netable/Netable/Netable.swift
@@ -117,7 +117,7 @@ open class Netable {
         if config.disableLogRedaction, let params = try? request.parameters.toParameterDictionary(encodingStrategy: request.jsonKeyEncodingStrategy) {
             log(.requestBody(body: params))
         } else {
-            log(.requestBody(body: request.safeParameters))
+            log(.requestBody(body: request.unredactedParameters))
         }
 
         let retryConfiguration = self.retryConfiguration

--- a/Netable/Netable/Netable.swift
+++ b/Netable/Netable/Netable.swift
@@ -100,10 +100,11 @@ open class Netable {
         let requestInfo = LogEvent.RequestInfo(
             urlString:  urlRequest.url?.absoluteString ?? "UNDEFINED",
             method: request.method,
-            headers: urlRequest.allHTTPHeaderFields ?? [:],
-            params: try? request.parameters.toParameterDictionary(encodingStrategy: request.jsonKeyEncodingStrategy))
+            headers: urlRequest.allHTTPHeaderFields ?? [:]
+        )
 
         log(.requestStarted(request: requestInfo))
+        log(.requestBody(body: request.safeParameters))
 
         let retryConfiguration = self.retryConfiguration
 

--- a/Netable/Netable/Request.swift
+++ b/Netable/Netable/Request.swift
@@ -31,7 +31,7 @@ public protocol Request {
 
     /// Parameter keys whose values will be printed in full to logs.
     /// By default, all parameters will be printed as `<REDACTED>` to logs.
-    var safeParameterKeys: Set<String> { get }
+    var unredactedParameterKeys: Set<String> { get }
 
     /// Optional: The key decoding strategy to be used when decoding return JSON.
     var jsonKeyDecodingStrategy: JSONDecoder.KeyDecodingStrategy { get }
@@ -47,11 +47,11 @@ public protocol Request {
 }
 
 public extension Request {
-    var safeParameterKeys: Set<String> {
+    var unredactedParameterKeys: Set<String> {
         return Set<String>()
     }
 
-    var safeParameters: [String: String] {
+    var unredactedParameters: [String: String] {
         var output = [String: String]()
 
         guard let paramsDict = try? parameters.toParameterDictionary(encodingStrategy: self.jsonKeyEncodingStrategy) else {
@@ -59,7 +59,7 @@ public extension Request {
         }
         
         for (key, value) in paramsDict {
-            if safeParameterKeys.contains(key) {
+            if unredactedParameterKeys.contains(key) {
                 output[key] = value
             } else {
                 output[key] = "<REDACTED>"

--- a/Netable/NetableExample/Requests/LoginRequest.swift
+++ b/Netable/NetableExample/Requests/LoginRequest.swift
@@ -33,7 +33,7 @@ struct LoginRequest: Request {
 
    public var parameters: LoginParams
 
-    public var safeParameterKeys: Set<String> {
+    public var unredactedParameterKeys: Set<String> {
         ["first_name", "username"]
     }
 }

--- a/Netable/NetableExample/Requests/LoginRequest.swift
+++ b/Netable/NetableExample/Requests/LoginRequest.swift
@@ -32,4 +32,8 @@ struct LoginRequest: Request {
    }
 
    public var parameters: LoginParams
+
+    public var safeParameterKeys: Set<String> {
+        ["first_name", "username"]
+    }
 }


### PR DESCRIPTION
- Adds a new log event, `requestBody` that accepts a `[String: String]` dictionary to print out. 

- Adds a new optional field to `Request`, `safeParameterKeys` that accepts a set of strings that are safe to print to the console.

- Also adds a computed variable, `safeParameters` that returns a dictionary of the parameters with any values not defined as safe replaced with <REDACTED>

Also bumped the version number to 1.0 in anticipation of our next release.