### PR TITLE
change netable constructor to not allow directly settings an URLSessionConfiguration 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+### Added
+- [74] Change Netable constructor to remove the option to directly set a URLSessionConfiguration and instead only expose the `timeout` option.
+
 ## [0.10.3] - 12-01-21
 ### Changed
 - Fixed an issue with logging successful requests that was preventing finalized data from being printed properly.

--- a/Netable/Netable.xcodeproj/project.pbxproj
+++ b/Netable/Netable.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		C64F8594241FE70E0028E0E9 /* ExamplesTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64F8593241FE70E0028E0E9 /* ExamplesTableViewController.swift */; };
 		C64F859C241FF09D0028E0E9 /* LoginRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64F859B241FF09D0028E0E9 /* LoginRequest.swift */; };
 		C64F859E241FF8E60028E0E9 /* PostLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64F859D241FF8E60028E0E9 /* PostLoginViewController.swift */; };
+		C65289F526D01829009D486B /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65289F426D01829009D486B /* Config.swift */; };
 		C66901AF241C1B0A002954C5 /* CustomLogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66901AE241C1B0A002954C5 /* CustomLogDestination.swift */; };
 		C66A8BF72436619F0052A1AF /* CancelRequestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66A8BF62436619F0052A1AF /* CancelRequestViewController.swift */; };
 		C66A8BFD24367E910052A1AF /* DecodeSnakeCaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66A8BFA24367E910052A1AF /* DecodeSnakeCaseViewController.swift */; };
@@ -111,6 +112,7 @@
 		C64F8593241FE70E0028E0E9 /* ExamplesTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamplesTableViewController.swift; sourceTree = "<group>"; };
 		C64F859B241FF09D0028E0E9 /* LoginRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRequest.swift; sourceTree = "<group>"; };
 		C64F859D241FF8E60028E0E9 /* PostLoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostLoginViewController.swift; sourceTree = "<group>"; };
+		C65289F426D01829009D486B /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		C66901AE241C1B0A002954C5 /* CustomLogDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomLogDestination.swift; sourceTree = "<group>"; };
 		C66A8BF62436619F0052A1AF /* CancelRequestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelRequestViewController.swift; sourceTree = "<group>"; };
 		C66A8BFA24367E910052A1AF /* DecodeSnakeCaseViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecodeSnakeCaseViewController.swift; sourceTree = "<group>"; };
@@ -188,8 +190,9 @@
 			isa = PBXGroup;
 			children = (
 				C64F8591241FE4870028E0E9 /* CHANGELOG.md */,
-				B8C9289C23E9FA0E00DB2B37 /* Error.swift */,
+				C65289F426D01829009D486B /* Config.swift */,
 				A63ABCCB24ABBFCC004DE84E /* DelayedOperations.swift */,
+				B8C9289C23E9FA0E00DB2B37 /* Error.swift */,
 				B8C928A223E9FBEC00DB2B37 /* HTTPMethod.swift */,
 				B8C9288423E9F68000DB2B37 /* Info.plist */,
 				C6953F41241A95830044D278 /* LogDestination.swift */,
@@ -451,6 +454,7 @@
 				A63ABCCC24ABBFCC004DE84E /* DelayedOperations.swift in Sources */,
 				B8C9289F23E9FB1500DB2B37 /* URLRequest+EncodeParameters.swift in Sources */,
 				B8C928A123E9FBA100DB2B37 /* Request.swift in Sources */,
+				C65289F526D01829009D486B /* Config.swift in Sources */,
 				C6953F42241A95830044D278 /* LogDestination.swift in Sources */,
 				B8C9289D23E9FA0E00DB2B37 /* Error.swift in Sources */,
 				B8C928A323E9FBEC00DB2B37 /* HTTPMethod.swift in Sources */,

--- a/Netable/Netable/Config.swift
+++ b/Netable/Netable/Config.swift
@@ -1,0 +1,27 @@
+//
+//  Config.swift
+//  Netable
+//
+//  Created by Brendan on 2021-08-20.
+//  Copyright © 2021 Steamclock Software. All rights reserved.
+//
+
+import Foundation
+
+public struct Config {
+    var timeout: TimeInterval?
+
+    public init(timeout: TimeInterval? = nil) {
+        self.timeout = timeout
+    }
+
+    internal var urlSessionConfig: URLSessionConfiguration {
+        let config = URLSessionConfiguration()
+
+        if let timeout = timeout {
+            config.timeoutIntervalForRequest = timeout
+        }
+
+        return config
+    }
+}

--- a/Netable/Netable/Config.swift
+++ b/Netable/Netable/Config.swift
@@ -15,13 +15,13 @@ public struct Config {
         self.timeout = timeout
     }
 
-    internal var urlSessionConfig: URLSessionConfiguration {
-        let config = URLSessionConfiguration()
+    internal var urlSession: URLSession {
+        let urlSession = URLSession(configuration: .ephemeral)
 
         if let timeout = timeout {
-            config.timeoutIntervalForRequest = timeout
+            urlSession.configuration.timeoutIntervalForRequest = timeout
         }
 
-        return config
+        return urlSession
     }
 }

--- a/Netable/Netable/Config.swift
+++ b/Netable/Netable/Config.swift
@@ -14,14 +14,4 @@ public struct Config {
     public init(timeout: TimeInterval? = nil) {
         self.timeout = timeout
     }
-
-    internal var urlSession: URLSession {
-        let urlSession = URLSession(configuration: .ephemeral)
-
-        if let timeout = timeout {
-            urlSession.configuration.timeoutIntervalForRequest = timeout
-        }
-
-        return urlSession
-    }
 }

--- a/Netable/Netable/Netable.swift
+++ b/Netable/Netable/Netable.swift
@@ -53,7 +53,11 @@ open class Netable {
         self.config = config
         self.logDestination = logDestination
         self.retryConfiguration = retryConfiguration
-        self.urlSession = config.urlSession
+
+        self.urlSession = URLSession(configuration: .ephemeral)
+        if let timeout = config.timeout {
+            self.urlSession.configuration.timeoutIntervalForRequest = timeout
+        }
 
         log(.startupInfo(baseURL: baseURL, logDestination: logDestination))
     }

--- a/Netable/Netable/Netable.swift
+++ b/Netable/Netable/Netable.swift
@@ -22,6 +22,9 @@ open class Netable {
     /// The URL session requests are run through.
     private let urlSession: URLSession
 
+    /// The Netable config supplied when creating an instance.
+    private let config: Config
+
     /// The base URL of your api endpoint.
     public var baseURL: URL
 
@@ -47,6 +50,7 @@ open class Netable {
      */
     public init(baseURL: URL, config: Config = Config(), logDestination: LogDestination = DefaultLogDestination(), retryConfiguration: RetryConfiguration = RetryConfiguration()) {
         self.baseURL = baseURL
+        self.config = config
         self.logDestination = logDestination
         self.retryConfiguration = retryConfiguration
         self.urlSession = URLSession(configuration: config.urlSessionConfig)

--- a/Netable/Netable/Netable.swift
+++ b/Netable/Netable/Netable.swift
@@ -53,7 +53,7 @@ open class Netable {
         self.config = config
         self.logDestination = logDestination
         self.retryConfiguration = retryConfiguration
-        self.urlSession = URLSession(configuration: config.urlSessionConfig)
+        self.urlSession = config.urlSession
 
         log(.startupInfo(baseURL: baseURL, logDestination: logDestination))
     }

--- a/Netable/Netable/Netable.swift
+++ b/Netable/Netable/Netable.swift
@@ -41,13 +41,15 @@ open class Netable {
      * Create a new instance of `Netable` with a base URL.
      *
      * - parameter baseURL: The base URL of your endpoint.
-     * - parameter configuration: Configuration such as timeouts and caching policies for the underlying url session.
+     * - parameter config: Configuration such as timeouts and caching policies for the underlying url session.
+     * - parameter logDestination: Destination to send request logs to. Default is DefaultLogDestination
+     * - parameter retryConfiguration: Configuration for request retry policies
      */
-    public init(baseURL: URL, configuration: URLSessionConfiguration = .ephemeral, logDestination: LogDestination = DefaultLogDestination(), retryConfiguration: RetryConfiguration = RetryConfiguration()) {
+    public init(baseURL: URL, config: Config = Config(), logDestination: LogDestination = DefaultLogDestination(), retryConfiguration: RetryConfiguration = RetryConfiguration()) {
         self.baseURL = baseURL
-        self.urlSession = URLSession(configuration: configuration)
         self.logDestination = logDestination
         self.retryConfiguration = retryConfiguration
+        self.urlSession = URLSession(configuration: config.urlSessionConfig)
 
         log(.startupInfo(baseURL: baseURL, logDestination: logDestination))
     }


### PR DESCRIPTION
Instead we accept a new `Config` struct containing the timeout option.

@nbrooke do we want to still expose the caching policy stuff? Does anyone actually use `default` in practice?