### PR TITLE
Add support for global error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [UNRELEASED]
 ### Added
 - [74] Change Netable constructor to remove the option to directly set a URLSessionConfiguration and instead only expose the `timeout` option.
+- [79] Add `requestFailedDelegate` and `requestFailedPublisher` to users to handle errors globally in addition to in `request` completion callbacks. Bumps minimum iOS version to 13.0.
 
 ## [0.10.3] - 12-01-21
 ### Changed

--- a/Netable/Netable.xcodeproj/project.pbxproj
+++ b/Netable/Netable.xcodeproj/project.pbxproj
@@ -47,6 +47,10 @@
 		C6953F42241A95830044D278 /* LogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6953F41241A95830044D278 /* LogDestination.swift */; };
 		C6D5C2F624E206C800A543CB /* DeleteRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D5C2F524E206C800A543CB /* DeleteRequest.swift */; };
 		C6D5C2F824E2085900A543CB /* SampleDeleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D5C2F724E2085900A543CB /* SampleDeleteViewController.swift */; };
+		C6F4CFB026D582E8004E6BB8 /* RequestFailedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F4CFAF26D582E8004E6BB8 /* RequestFailedDelegate.swift */; };
+		C6F4CFB226D5874F004E6BB8 /* GlobalRequestFailureDelegateExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F4CFB126D5874F004E6BB8 /* GlobalRequestFailureDelegateExample.swift */; };
+		C6F4CFB426D5875F004E6BB8 /* GlobalRequestFailurePublisherExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F4CFB326D5875F004E6BB8 /* GlobalRequestFailurePublisherExample.swift */; };
+		C6F4CFB626D598B3004E6BB8 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = C6F4CFB526D598B3004E6BB8 /* README.md */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -123,6 +127,10 @@
 		C6953F41241A95830044D278 /* LogDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogDestination.swift; sourceTree = "<group>"; };
 		C6D5C2F524E206C800A543CB /* DeleteRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteRequest.swift; sourceTree = "<group>"; };
 		C6D5C2F724E2085900A543CB /* SampleDeleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleDeleteViewController.swift; sourceTree = "<group>"; };
+		C6F4CFAF26D582E8004E6BB8 /* RequestFailedDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestFailedDelegate.swift; sourceTree = "<group>"; };
+		C6F4CFB126D5874F004E6BB8 /* GlobalRequestFailureDelegateExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalRequestFailureDelegateExample.swift; sourceTree = "<group>"; };
+		C6F4CFB326D5875F004E6BB8 /* GlobalRequestFailurePublisherExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalRequestFailurePublisherExample.swift; sourceTree = "<group>"; };
+		C6F4CFB526D598B3004E6BB8 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../../README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -189,6 +197,7 @@
 		B8C9288223E9F68000DB2B37 /* Netable */ = {
 			isa = PBXGroup;
 			children = (
+				C6F4CFB526D598B3004E6BB8 /* README.md */,
 				C64F8591241FE4870028E0E9 /* CHANGELOG.md */,
 				C65289F426D01829009D486B /* Config.swift */,
 				A63ABCCB24ABBFCC004DE84E /* DelayedOperations.swift */,
@@ -205,6 +214,7 @@
 				B8C9289E23E9FB1500DB2B37 /* URLRequest+EncodeParameters.swift */,
 				B8C928A623E9FC8D00DB2B37 /* URLRequest+EncodeURL.swift */,
 				B8C928A423E9FC3E00DB2B37 /* URLRequest+Multipart.swift */,
+				C6F4CFAF26D582E8004E6BB8 /* RequestFailedDelegate.swift */,
 			);
 			path = Netable;
 			sourceTree = "<group>";
@@ -263,6 +273,8 @@
 				C6D5C2F724E2085900A543CB /* SampleDeleteViewController.swift */,
 				23B627092435332200BD888D /* SampleDownloadViewController.swift */,
 				B822C8F123F20E8900D7BDAD /* SampleGetViewController.swift */,
+				C6F4CFB126D5874F004E6BB8 /* GlobalRequestFailureDelegateExample.swift */,
+				C6F4CFB326D5875F004E6BB8 /* GlobalRequestFailurePublisherExample.swift */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -406,6 +418,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C6F4CFB626D598B3004E6BB8 /* README.md in Resources */,
 				C64F8590241FE4670028E0E9 /* Netable.podspec in Resources */,
 				C64F8592241FE4870028E0E9 /* CHANGELOG.md in Resources */,
 			);
@@ -434,12 +447,14 @@
 				C66A8BF72436619F0052A1AF /* CancelRequestViewController.swift in Sources */,
 				B822C8F223F20E8900D7BDAD /* SampleGetViewController.swift in Sources */,
 				23B6270A2435332200BD888D /* SampleDownloadViewController.swift in Sources */,
+				C6F4CFB426D5875F004E6BB8 /* GlobalRequestFailurePublisherExample.swift in Sources */,
 				B822C8EE23F20E8900D7BDAD /* AppDelegate.swift in Sources */,
 				C6D5C2F624E206C800A543CB /* DeleteRequest.swift in Sources */,
 				C66A8BFE24367E910052A1AF /* CustomLoggerViewController.swift in Sources */,
 				C64F859C241FF09D0028E0E9 /* LoginRequest.swift in Sources */,
 				C6D5C2F824E2085900A543CB /* SampleDeleteViewController.swift in Sources */,
 				C64F859E241FF8E60028E0E9 /* PostLoginViewController.swift in Sources */,
+				C6F4CFB226D5874F004E6BB8 /* GlobalRequestFailureDelegateExample.swift in Sources */,
 				B822C8F023F20E8900D7BDAD /* SceneDelegate.swift in Sources */,
 				23B627082435329800BD888D /* DownloadCatImageRequest.swift in Sources */,
 			);
@@ -452,6 +467,7 @@
 				B8C928A723E9FC8D00DB2B37 /* URLRequest+EncodeURL.swift in Sources */,
 				B8C928A523E9FC3E00DB2B37 /* URLRequest+Multipart.swift in Sources */,
 				A63ABCCC24ABBFCC004DE84E /* DelayedOperations.swift in Sources */,
+				C6F4CFB026D582E8004E6BB8 /* RequestFailedDelegate.swift in Sources */,
 				B8C9289F23E9FB1500DB2B37 /* URLRequest+EncodeParameters.swift in Sources */,
 				B8C928A123E9FBA100DB2B37 /* Request.swift in Sources */,
 				C65289F526D01829009D486B /* Config.swift in Sources */,
@@ -684,7 +700,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Netable/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -714,7 +730,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Netable/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Netable/Netable/Netable.swift
+++ b/Netable/Netable/Netable.swift
@@ -19,7 +19,6 @@ func CACurrentMediaTime() -> TimeInterval {
 }
 #endif
 
-@available(iOS 13.0, *)
 open class Netable {
     /// The URL session requests are run through.
     private let urlSession: URLSession

--- a/Netable/Netable/RequestFailedDelegate.swift
+++ b/Netable/Netable/RequestFailedDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  RequestFailedDelegate.swift
+//  Netable
+//
+//  Created by Brendan on 2021-08-24.
+//  Copyright © 2021 Steamclock Software. All rights reserved.
+//
+
+import Foundation
+
+public protocol RequestFailureDelegate {
+    func requestDidFail<T: Request>(_ request: T, error: NetableError)
+}

--- a/Netable/NetableExample/Resources/Base.lproj/Main.storyboard
+++ b/Netable/NetableExample/Resources/Base.lproj/Main.storyboard
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Fje-Dr-3u6">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Fje-Dr-3u6">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -14,10 +16,10 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="H4n-dv-4jq">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="ce8-LX-yVV">
-                                <rect key="frame" x="0.0" y="28" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="24.5" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ce8-LX-yVV" id="BUu-WL-iEN">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -52,12 +54,12 @@
                                 </constraints>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="8Iu-f5-n8F" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Axn-E1-tsR"/>
                             <constraint firstItem="8Iu-f5-n8F" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="MmL-zU-4wL"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <connections>
                         <outlet property="catImageView" destination="8Iu-f5-n8F" id="FPX-gG-aa4"/>
@@ -65,7 +67,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1479.7101449275362" y="-81.026785714285708"/>
+            <point key="canvasLocation" x="1484" y="-81"/>
         </scene>
         <!--Cancel Request View Controller-->
         <scene sceneID="a5V-Tg-tyu">
@@ -74,8 +76,8 @@
                     <view key="view" contentMode="scaleToFill" id="gUW-yh-4a9">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="7n4-DW-jOF"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xKE-4d-afQ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -108,14 +110,14 @@
                                 </subviews>
                             </stackView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="D8h-b8-hBu"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="3WS-fq-cHH" firstAttribute="centerY" secondItem="OQ5-wd-jQ3" secondAttribute="centerY" id="52p-MW-5qA"/>
                             <constraint firstItem="D8h-b8-hBu" firstAttribute="trailing" secondItem="3WS-fq-cHH" secondAttribute="trailing" constant="50" id="KDz-Uu-bJP"/>
                             <constraint firstItem="3WS-fq-cHH" firstAttribute="centerX" secondItem="OQ5-wd-jQ3" secondAttribute="centerX" id="S30-nf-vmv"/>
                             <constraint firstItem="3WS-fq-cHH" firstAttribute="leading" secondItem="D8h-b8-hBu" secondAttribute="leading" constant="50" id="hvP-VC-cFm"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="D8h-b8-hBu"/>
                     </view>
                     <connections>
                         <outlet property="paramsLabel" destination="J6g-cz-Dnc" id="hDv-ke-CYD"/>
@@ -153,7 +155,7 @@
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
-                                    <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6xm-6X-UBK">
+                                    <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6xm-6X-UBK">
                                         <rect key="frame" x="0.0" y="84" width="314" height="30"/>
                                         <state key="normal" title="Submit"/>
                                         <connections>
@@ -163,7 +165,8 @@
                                 </subviews>
                             </stackView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="YY3-uS-o34"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="s76-aO-sNB" firstAttribute="leading" secondItem="YY3-uS-o34" secondAttribute="leading" constant="50" id="25H-49-oMt"/>
                             <constraint firstItem="CVk-j5-9we" firstAttribute="leading" secondItem="YY3-uS-o34" secondAttribute="leading" constant="50" id="4HZ-rf-xDP"/>
@@ -172,7 +175,6 @@
                             <constraint firstItem="YY3-uS-o34" firstAttribute="trailing" secondItem="s76-aO-sNB" secondAttribute="trailing" constant="50" id="VjX-yl-ZQi"/>
                             <constraint firstItem="s76-aO-sNB" firstAttribute="centerY" secondItem="TIT-Ua-GWn" secondAttribute="centerY" multiplier="1.2" id="c8c-IT-hQw"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="YY3-uS-o34"/>
                     </view>
                     <connections>
                         <outlet property="passwordField" destination="WUd-H8-Bop" id="x5k-GN-IrU"/>
@@ -201,12 +203,12 @@
                                 </constraints>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="qnE-It-PbL"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="dJ6-2r-beG" firstAttribute="centerY" secondItem="gNh-Iz-PIN" secondAttribute="centerY" id="XJB-pU-tlc"/>
                             <constraint firstItem="dJ6-2r-beG" firstAttribute="centerX" secondItem="gNh-Iz-PIN" secondAttribute="centerX" id="gSf-hk-YRi"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="qnE-It-PbL"/>
                     </view>
                     <connections>
                         <outlet property="imageView" destination="dJ6-2r-beG" id="6rS-xQ-2b4"/>
@@ -250,12 +252,12 @@
                                 </constraints>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="s7b-LR-j92"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="XP1-w3-d7y" firstAttribute="centerX" secondItem="3vN-a2-JZb" secondAttribute="centerX" id="7Sl-4A-amU"/>
                             <constraint firstItem="XP1-w3-d7y" firstAttribute="centerY" secondItem="3vN-a2-JZb" secondAttribute="centerY" id="uYo-hz-nLF"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="s7b-LR-j92"/>
                     </view>
                     <connections>
                         <outlet property="imageView" destination="XP1-w3-d7y" id="wsN-Lf-5id"/>
@@ -280,12 +282,12 @@
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="RMY-HQ-A2a"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="lMU-nD-fTC" firstAttribute="centerX" secondItem="aH3-Rg-dZ4" secondAttribute="centerX" id="Hj6-cX-x85"/>
                             <constraint firstItem="lMU-nD-fTC" firstAttribute="centerY" secondItem="aH3-Rg-dZ4" secondAttribute="centerY" id="Owd-dW-JrO"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="RMY-HQ-A2a"/>
                     </view>
                     <connections>
                         <outlet property="label" destination="lMU-nD-fTC" id="Oj7-jj-IQe"/>
@@ -295,5 +297,72 @@
             </objects>
             <point key="canvasLocation" x="3448" y="576"/>
         </scene>
+        <!--GET Cat-->
+        <scene sceneID="REO-CL-QW0">
+            <objects>
+                <viewController storyboardIdentifier="GlobalRequestFailureDelegateExample" title="GET Cat" id="r95-de-DXL" customClass="GlobalRequestFailureDelegateExample" customModule="NetableExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="o6M-rY-40H">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fCk-91-zZB">
+                                <rect key="frame" x="57" y="298" width="300" height="300"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="300" id="0vQ-Zd-Q4X"/>
+                                    <constraint firstAttribute="width" constant="300" id="ISP-aR-8Jk"/>
+                                </constraints>
+                            </imageView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6fE-y0-Jsq"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="fCk-91-zZB" firstAttribute="centerY" secondItem="o6M-rY-40H" secondAttribute="centerY" id="BOp-vE-w3p"/>
+                            <constraint firstItem="fCk-91-zZB" firstAttribute="centerX" secondItem="o6M-rY-40H" secondAttribute="centerX" id="Y9O-Mj-9jj"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="catImageView" destination="fCk-91-zZB" id="YpT-9B-ghB"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ffZ-19-YSy" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1499" y="-757"/>
+        </scene>
+        <!--GET Cat-->
+        <scene sceneID="gHO-xt-N3S">
+            <objects>
+                <viewController storyboardIdentifier="GlobalRequestFailurePublisherExample" title="GET Cat" id="eSr-jT-GP3" customClass="GlobalRequestFailurePublisherExample" customModule="NetableExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="oTZ-bd-l7n">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="rmA-ld-gyQ">
+                                <rect key="frame" x="57" y="298" width="300" height="300"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="300" id="BSE-G5-OpE"/>
+                                    <constraint firstAttribute="height" constant="300" id="zXo-RC-wNx"/>
+                                </constraints>
+                            </imageView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="SAj-hB-ITP"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="rmA-ld-gyQ" firstAttribute="centerY" secondItem="oTZ-bd-l7n" secondAttribute="centerY" id="Qjh-OH-iKL"/>
+                            <constraint firstItem="rmA-ld-gyQ" firstAttribute="centerX" secondItem="oTZ-bd-l7n" secondAttribute="centerX" id="mNT-4w-Yxe"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="catImageView" destination="rmA-ld-gyQ" id="S7w-cY-qWS"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="uzA-DK-cfK" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2151" y="-757"/>
+        </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Netable/NetableExample/View Controllers/ExamplesTableViewController.swift
+++ b/Netable/NetableExample/View Controllers/ExamplesTableViewController.swift
@@ -29,7 +29,9 @@ class ExamplesTableViewController: UITableViewController {
                 RequestRow(title: "Empty Logger Example", vcIdentifier: "EmptyLoggerViewController"),
                 RequestRow(title: "Decode_snake_case", vcIdentifier: "DecodeSnakeCaseViewController"),
                 RequestRow(title: "Cancel Request", vcIdentifier: "CancelRequestViewController"),
-                RequestRow(title: "Delete Example", vcIdentifier: "SampleDeleteViewController")
+                RequestRow(title: "Delete Example", vcIdentifier: "SampleDeleteViewController"),
+                RequestRow(title: "Global Error Delegate", vcIdentifier: "GlobalRequestFailureDelegateExample"),
+                RequestRow(title: "Global Error Publisher", vcIdentifier: "GlobalRequestFailurePublisherExample")
             ]
         ),
         RequestSet(sectionTitle: "POST", requestRows: [RequestRow(title: "POST Sample Login", vcIdentifier: "PostLoginViewController")]),

--- a/Netable/NetableExample/View Controllers/GlobalRequestFailureDelegateExample.swift
+++ b/Netable/NetableExample/View Controllers/GlobalRequestFailureDelegateExample.swift
@@ -1,0 +1,44 @@
+//
+//  GlobalRequestFailureDelegateExample.swift
+//  NetableExample
+//
+//  Created by Brendan on 2021-08-24.
+//  Copyright © 2021 Steamclock Software. All rights reserved.
+//
+
+import Netable
+import SwiftUI
+
+class GlobalRequestFailureDelegateExample: UIViewController {
+
+    @IBOutlet private var catImageView: UIImageView!
+
+    /// Create a Netable instance using the default log destination
+    /// Note we're intentionally using an endpoint here we know will return a 404 to test error handling
+    private let netable = Netable(baseURL: URL(string: "https://api.thecatapi.com/404")!)
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        netable.requestFailureDelegate = self
+
+        netable.request(GetCatRequest()) { [weak self] result in
+            guard let self = self else { return }
+
+            // Since we don't care about the failure case, we can swap our usual switch statement out for an `if case`!
+            if case .success(let image) = result {
+                self.catImageView.image = image
+            }
+        }
+    }
+}
+
+extension GlobalRequestFailureDelegateExample: RequestFailureDelegate {
+    func requestDidFail<T>(_ request: T, error: NetableError) where T : Request {
+        let alert = UIAlertController(title: "Uh oh!", message: error.errorDescription, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+}
+
+

--- a/Netable/NetableExample/View Controllers/GlobalRequestFailurePublisherExample.swift
+++ b/Netable/NetableExample/View Controllers/GlobalRequestFailurePublisherExample.swift
@@ -1,0 +1,40 @@
+//
+//  GlobalRequestFailurePublisherExample.swift
+//  NetableExample
+//
+//  Created by Brendan on 2021-08-24.
+//  Copyright © 2021 Steamclock Software. All rights reserved.
+//
+
+import Combine
+import Netable
+import SwiftUI
+
+class GlobalRequestFailurePublisherExample: UIViewController {
+
+    @IBOutlet private var catImageView: UIImageView!
+
+    /// Create a Netable instance using the default log destination
+    /// Note we're intentionally using an endpoint here we know will return a 404 to test error handling
+    private let netable = Netable(baseURL: URL(string: "https://api.thecatapi.com/404")!)
+    private var cancellables = [AnyCancellable]()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        netable.requestFailurePublisher.sink { error in
+            let alert = UIAlertController(title: "Uh oh!", message: error.errorDescription, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default))
+            self.present(alert, animated: true)
+        }.store(in: &cancellables)
+
+        netable.request(GetCatRequest()) { [weak self] result in
+            guard let self = self else { return }
+
+            // Since we don't care about the failure case, we can swap our usual switch statement out for an `if case`!
+            if case .success(let image) = result {
+                self.catImageView.image = image
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -133,6 +133,36 @@ netable.request(GetCatImageURL()) { result in
 }
 ```
 
+### Handling Errors
+
+In addition to handling errors locally through the `completion` callback provided by `request()`,  we provide two ways to handle errors globally. These can be useful for doing things like presenting errors in the UI for common error cases across multiple requests, or catching things like failed authentication requests to clear a stored user.
+
+#### Using `requestFailureDelegate`
+
+See [GlobalRequestFailureDelegate]() in the Example project for a more detailed example.
+
+```swift
+extension GlobalRequestFailureDelegateExample: RequestFailureDelegate {
+    func requestDidFail<T>(_ request: T, error: NetableError) where T : Request {
+        let alert = UIAlertController(title: "Uh oh!", message: error.errorDescription, preferredStyle: .alert)
+        present(alert, animated: true)
+    }
+}
+```
+
+#### Using `requestFailurePublisher`
+
+If you prefer `Combine`, you can subscribe to this publisher to recieve `NetableErrors` from elsewhere in your app.
+
+See [GlobalRequestFailurePublisher]() in the Example project for a more detailed example.
+
+```swift
+netable.requestFailurePublisher.sink { error in
+    let alert = UIAlertController(title: "Uh oh!", message: error.errorDescription, preferredStyle: .alert)
+    self.present(alert, animated: true)
+}.store(in: &cancellables)
+```
+
 ### Full Documentation
 
 [In-depth documentation](https://steamclock.github.io/netable/) is provided through Jazzy and GitHub Pages.  


### PR DESCRIPTION
Fixes #79 

After some great discussion in the original ticket, I think this is a pretty reasonable way forward to adding support for global error handling. Changes are:
- Bump minimum iOS version to 13.0. This is required to support the error publisher.
- Add `requestFailureDelegate` and `requestFailurePublisher`