### PR TITLE
add combine support for requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [UNRELEASED]
 ### Added
 - [60] Add better handling for printing request bodies to the console, including some default redaction for sensitive parameters.
+- [64] Add an alternate `request` format that allows you to use Combine to process results.
 - [73] Add more helpful decoding error descriptions
 - [74] Change Netable constructor to remove the option to directly set a URLSessionConfiguration and instead only expose the `timeout` option.
 - [76] Add an option to set json en/decoding strategies in the Netable config constructor in addition to per-request.

--- a/Netable/Netable.xcodeproj/project.pbxproj
+++ b/Netable/Netable.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		B8C928A523E9FC3E00DB2B37 /* URLRequest+Multipart.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C928A423E9FC3E00DB2B37 /* URLRequest+Multipart.swift */; };
 		B8C928A723E9FC8D00DB2B37 /* URLRequest+EncodeURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C928A623E9FC8D00DB2B37 /* URLRequest+EncodeURL.swift */; };
 		B8C928A923E9FDCC00DB2B37 /* Netable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C928A823E9FDCC00DB2B37 /* Netable.swift */; };
+		C64689A526DD934400D2AFDD /* CombineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64689A426DD934400D2AFDD /* CombineViewController.swift */; };
 		C64F8590241FE4670028E0E9 /* Netable.podspec in Resources */ = {isa = PBXBuildFile; fileRef = C64F858F241FE4670028E0E9 /* Netable.podspec */; };
 		C64F8592241FE4870028E0E9 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = C64F8591241FE4870028E0E9 /* CHANGELOG.md */; };
 		C64F8594241FE70E0028E0E9 /* ExamplesTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64F8593241FE70E0028E0E9 /* ExamplesTableViewController.swift */; };
@@ -113,6 +114,7 @@
 		B8C928A423E9FC3E00DB2B37 /* URLRequest+Multipart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Multipart.swift"; sourceTree = "<group>"; };
 		B8C928A623E9FC8D00DB2B37 /* URLRequest+EncodeURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+EncodeURL.swift"; sourceTree = "<group>"; };
 		B8C928A823E9FDCC00DB2B37 /* Netable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Netable.swift; sourceTree = "<group>"; };
+		C64689A426DD934400D2AFDD /* CombineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineViewController.swift; sourceTree = "<group>"; };
 		C64F858F241FE4670028E0E9 /* Netable.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Netable.podspec; path = ../../Netable.podspec; sourceTree = "<group>"; };
 		C64F8591241FE4870028E0E9 /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = CHANGELOG.md; path = ../../CHANGELOG.md; sourceTree = "<group>"; };
 		C64F8593241FE70E0028E0E9 /* ExamplesTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamplesTableViewController.swift; sourceTree = "<group>"; };
@@ -268,16 +270,17 @@
 			isa = PBXGroup;
 			children = (
 				C66A8BF62436619F0052A1AF /* CancelRequestViewController.swift */,
+				C64689A426DD934400D2AFDD /* CombineViewController.swift */,
 				C66A8BFB24367E910052A1AF /* CustomLoggerViewController.swift */,
 				C66A8BFA24367E910052A1AF /* DecodeSnakeCaseViewController.swift */,
 				C66A8BFC24367E910052A1AF /* EmptyLoggerViewController.swift */,
 				C64F8593241FE70E0028E0E9 /* ExamplesTableViewController.swift */,
+				C6F4CFB126D5874F004E6BB8 /* GlobalRequestFailureDelegateExample.swift */,
+				C6F4CFB326D5875F004E6BB8 /* GlobalRequestFailurePublisherExample.swift */,
 				C64F859D241FF8E60028E0E9 /* PostLoginViewController.swift */,
 				C6D5C2F724E2085900A543CB /* SampleDeleteViewController.swift */,
 				23B627092435332200BD888D /* SampleDownloadViewController.swift */,
 				B822C8F123F20E8900D7BDAD /* SampleGetViewController.swift */,
-				C6F4CFB126D5874F004E6BB8 /* GlobalRequestFailureDelegateExample.swift */,
-				C6F4CFB326D5875F004E6BB8 /* GlobalRequestFailurePublisherExample.swift */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -443,6 +446,7 @@
 			files = (
 				C66A8BFF24367E910052A1AF /* EmptyLoggerViewController.swift in Sources */,
 				C66901AF241C1B0A002954C5 /* CustomLogDestination.swift in Sources */,
+				C64689A526DD934400D2AFDD /* CombineViewController.swift in Sources */,
 				B822C90023F210D800D7BDAD /* GetCatRequest.swift in Sources */,
 				C64F8594241FE70E0028E0E9 /* ExamplesTableViewController.swift in Sources */,
 				C66A8C0224367EBA0052A1AF /* SampleGETJSON.swift in Sources */,

--- a/Netable/NetableExample/Resources/Base.lproj/Main.storyboard
+++ b/Netable/NetableExample/Resources/Base.lproj/Main.storyboard
@@ -295,7 +295,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Fht-6p-Thg" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3448" y="576"/>
+            <point key="canvasLocation" x="3438" y="576"/>
         </scene>
         <!--GET Cat-->
         <scene sceneID="REO-CL-QW0">
@@ -358,6 +358,36 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="uzA-DK-cfK" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2151" y="-757"/>
+        </scene>
+        <!--Combine View Controller-->
+        <scene sceneID="Eek-oR-KAg">
+            <objects>
+                <viewController storyboardIdentifier="CombineViewController" id="Nil-Rv-jrI" customClass="CombineViewController" customModule="NetableExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="khU-Gg-Qkl">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r0z-P6-hCN">
+                                <rect key="frame" x="207" y="448" width="0.0" height="0.0"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="quu-8f-DjQ"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="r0z-P6-hCN" firstAttribute="centerX" secondItem="khU-Gg-Qkl" secondAttribute="centerX" id="IrE-sq-xO1"/>
+                            <constraint firstItem="r0z-P6-hCN" firstAttribute="centerY" secondItem="khU-Gg-Qkl" secondAttribute="centerY" id="tN6-Qs-hTv"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="label" destination="r0z-P6-hCN" id="CbY-1I-Hcu"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ith-wb-UFS" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4086" y="576"/>
         </scene>
     </scenes>
     <resources>

--- a/Netable/NetableExample/View Controllers/CombineViewController.swift
+++ b/Netable/NetableExample/View Controllers/CombineViewController.swift
@@ -1,0 +1,37 @@
+//
+//  CombineViewController.swift
+//  NetableExample
+//
+//  Created by Brendan on 2021-08-30.
+//  Copyright © 2021 Steamclock Software. All rights reserved.
+//
+
+import Combine
+import Netable
+import UIKit
+
+class CombineViewController: UIViewController {
+    @IBOutlet var label: UILabel!
+
+    /// Create a Netable instance using the default log destination.
+    private let netable = Netable(baseURL: URL(string: "https://api.thecatapi.com/v1/")!)
+    private var cancellables = [AnyCancellable]()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        netable.request(GetCatRequest()).sink(
+            receiveCompletion: { error in
+                let alert = UIAlertController(
+                    title: "Uh oh!",
+                    message: "GET failed with error: \(error)",
+                    preferredStyle: .alert
+                )
+
+                alert.addAction(UIAlertAction(title: "OK", style: .cancel))
+                self.present(alert, animated: true, completion: nil)
+            }, receiveValue: { finalResource in
+                self.label.text = "\(finalResource)"
+            }).store(in: &cancellables)
+    }
+}

--- a/Netable/NetableExample/View Controllers/ExamplesTableViewController.swift
+++ b/Netable/NetableExample/View Controllers/ExamplesTableViewController.swift
@@ -31,7 +31,8 @@ class ExamplesTableViewController: UITableViewController {
                 RequestRow(title: "Cancel Request", vcIdentifier: "CancelRequestViewController"),
                 RequestRow(title: "Delete Example", vcIdentifier: "SampleDeleteViewController"),
                 RequestRow(title: "Global Error Delegate", vcIdentifier: "GlobalRequestFailureDelegateExample"),
-                RequestRow(title: "Global Error Publisher", vcIdentifier: "GlobalRequestFailurePublisherExample")
+                RequestRow(title: "Global Error Publisher", vcIdentifier: "GlobalRequestFailurePublisherExample"),
+                RequestRow(title: "Combine Example", vcIdentifier: "CombineViewController")
             ]
         ),
         RequestSet(sectionTitle: "POST", requestRows: [RequestRow(title: "POST Sample Login", vcIdentifier: "PostLoginViewController")]),


### PR DESCRIPTION
For #64 

This adds a pretty simple second `request` function that returns a PassthroughSubject<FinalResource, NetableError>.

I had considered returning PassthroughSubject<Result<FinalResource, NetableError>, Never>(), since it more closely matches our other request function and leverages `Result`, but I think it makes more sense to match Combine. Is that reasonable? 