### PR TITLE
Improve Encoding of GraphQLMutation Inputs

### DIFF
--- a/Netable/Netable.xcodeproj/project.pbxproj
+++ b/Netable/Netable.xcodeproj/project.pbxproj
@@ -31,9 +31,9 @@
 		C61DC6F028CF9CE20089E912 /* GetAllPostsQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61DC6EF28CF9CE20089E912 /* GetAllPostsQuery.swift */; };
 		C61DC6F228CFB2D00089E912 /* GraphQLViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61DC6F128CFB2D00089E912 /* GraphQLViewController.swift */; };
 		C61DC6F428CFB2F40089E912 /* GraphQLRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61DC6F328CFB2F40089E912 /* GraphQLRepository.swift */; };
-		C61DC6F628CFC09E0089E912 /* UpdateFilmMutation.graphql in Resources */ = {isa = PBXBuildFile; fileRef = C61DC6F528CFC09E0089E912 /* UpdateFilmMutation.graphql */; };
+		C61DC6F628CFC09E0089E912 /* UpdatePostMutation.graphql in Resources */ = {isa = PBXBuildFile; fileRef = C61DC6F528CFC09E0089E912 /* UpdatePostMutation.graphql */; };
 		C61DC6F828CFC4360089E912 /* GraphQLMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61DC6F728CFC4360089E912 /* GraphQLMutation.swift */; };
-		C61DC6FA28CFD4260089E912 /* UpdateFilmMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61DC6F928CFD4250089E912 /* UpdateFilmMutation.swift */; };
+		C61DC6FA28CFD4260089E912 /* UpdatePostMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61DC6F928CFD4250089E912 /* UpdatePostMutation.swift */; };
 		C61DC6FC28CFDF3F0089E912 /* GraphQLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61DC6FB28CFDF3F0089E912 /* GraphQLRequest.swift */; };
 		C635DCB426D95D2A009F82A0 /* SmartUnwrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = C635DCB326D95D2A009F82A0 /* SmartUnwrap.swift */; };
 		C64EAB6926F2828E0093850A /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64EAB6826F2828E0093850A /* Post.swift */; };
@@ -132,9 +132,9 @@
 		C61DC6EF28CF9CE20089E912 /* GetAllPostsQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAllPostsQuery.swift; sourceTree = "<group>"; };
 		C61DC6F128CFB2D00089E912 /* GraphQLViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLViewController.swift; sourceTree = "<group>"; };
 		C61DC6F328CFB2F40089E912 /* GraphQLRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLRepository.swift; sourceTree = "<group>"; };
-		C61DC6F528CFC09E0089E912 /* UpdateFilmMutation.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = UpdateFilmMutation.graphql; sourceTree = "<group>"; };
+		C61DC6F528CFC09E0089E912 /* UpdatePostMutation.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = UpdatePostMutation.graphql; sourceTree = "<group>"; };
 		C61DC6F728CFC4360089E912 /* GraphQLMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLMutation.swift; sourceTree = "<group>"; };
-		C61DC6F928CFD4250089E912 /* UpdateFilmMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateFilmMutation.swift; sourceTree = "<group>"; };
+		C61DC6F928CFD4250089E912 /* UpdatePostMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePostMutation.swift; sourceTree = "<group>"; };
 		C61DC6FB28CFDF3F0089E912 /* GraphQLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLRequest.swift; sourceTree = "<group>"; };
 		C635DCB326D95D2A009F82A0 /* SmartUnwrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartUnwrap.swift; sourceTree = "<group>"; };
 		C64EAB6826F2828E0093850A /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
@@ -279,8 +279,8 @@
 			children = (
 				C61DC6EB28CF9AEC0089E912 /* GetAllPostsQuery.graphql */,
 				C61DC6EF28CF9CE20089E912 /* GetAllPostsQuery.swift */,
-				C61DC6F528CFC09E0089E912 /* UpdateFilmMutation.graphql */,
-				C61DC6F928CFD4250089E912 /* UpdateFilmMutation.swift */,
+				C61DC6F528CFC09E0089E912 /* UpdatePostMutation.graphql */,
+				C61DC6F928CFD4250089E912 /* UpdatePostMutation.swift */,
 			);
 			path = GraphQL;
 			sourceTree = "<group>";
@@ -512,7 +512,7 @@
 				B822C8F523F20E8900D7BDAD /* Main.storyboard in Resources */,
 				C692788926F1259800917E65 /* login.json in Resources */,
 				C692788B26F125B400917E65 /* posts.json in Resources */,
-				C61DC6F628CFC09E0089E912 /* UpdateFilmMutation.graphql in Resources */,
+				C61DC6F628CFC09E0089E912 /* UpdatePostMutation.graphql in Resources */,
 				C61DC6EC28CF9AEC0089E912 /* GetAllPostsQuery.graphql in Resources */,
 				C64EAB7726F2B2E00093850A /* version.json in Resources */,
 				C692789B26F1463B00917E65 /* user.json in Resources */,
@@ -553,7 +553,7 @@
 				C692789D26F147FC00917E65 /* GetUserDetailsRequest.swift in Sources */,
 				C692789726F141A000917E65 /* ProfileViewController.swift in Sources */,
 				C64EAB6F26F2AD4F0093850A /* FailedRequest.swift in Sources */,
-				C61DC6FA28CFD4260089E912 /* UpdateFilmMutation.swift in Sources */,
+				C61DC6FA28CFD4260089E912 /* UpdatePostMutation.swift in Sources */,
 				C64EAB7A26F3AD370093850A /* PostOverviewCell.swift in Sources */,
 				C64EAB7126F2AE970093850A /* RootTabBarController.swift in Sources */,
 				C61DC6F028CF9CE20089E912 /* GetAllPostsQuery.swift in Sources */,

--- a/Netable/Netable/GraphQLMutation.swift
+++ b/Netable/Netable/GraphQLMutation.swift
@@ -18,11 +18,12 @@ public extension GraphQLMutation {
     var parameters: [String: String] {
         let params = getGraphQLQueryContents()
 
-        guard let encodedInputs = try? input.toParameterDictionary(encodingStrategy: .useDefaultKeys) else {
+        guard let encodedData = try? JSONEncoder().encode(input),
+              let encodedInputs = String(data: encodedData, encoding: .utf8) else {
             fatalError("Failed to unwrap inputs for graphQL mutation: \(type(of: self))")
         }
 
-        return ["query": params, "input": "\(encodedInputs)"]
+        return ["query": params, "input": encodedInputs]
     }
 
     var unredactedParameterKeys: Set<String> {

--- a/Netable/Netable/GraphQLRequest.swift
+++ b/Netable/Netable/GraphQLRequest.swift
@@ -69,8 +69,6 @@ public extension GraphQLRequest {
                 let params = try? String(contentsOfFile: resourcePath) else {
             fatalError("Failed to retrieve .graphql file for request: \(type(of: self)).")
         }
-        print("123")
-        print(params)
 
         return params
     }

--- a/Netable/Netable/GraphQLRequest.swift
+++ b/Netable/Netable/GraphQLRequest.swift
@@ -69,6 +69,8 @@ public extension GraphQLRequest {
                 let params = try? String(contentsOfFile: resourcePath) else {
             fatalError("Failed to retrieve .graphql file for request: \(type(of: self)).")
         }
+        print("123")
+        print(params)
 
         return params
     }

--- a/Netable/NetableExample/Repository/GraphQLRepository.swift
+++ b/Netable/NetableExample/Repository/GraphQLRepository.swift
@@ -35,8 +35,8 @@ class GraphQLRepository {
         let input = UpdatePostMutationInput(id: id, title: title)
         netable.request(UpdatePostMutation(input: input)) { result in
             switch result {
-            case .success(let posts):
-                print(posts)
+            case .success(let post):
+                print("Updated \(post)")
             case .failure(let error):
                 print("failure: \(error.localizedDescription)")
             }

--- a/Netable/NetableExample/Repository/GraphQLRepository.swift
+++ b/Netable/NetableExample/Repository/GraphQLRepository.swift
@@ -30,4 +30,16 @@ class GraphQLRepository {
             }
         }
     }
+
+    func updatePost(id: String, title: String) {
+        let input = UpdatePostMutationInput(id: id, title: title)
+        netable.request(UpdatePostMutation(input: input)) { result in
+            switch result {
+            case .success(let posts):
+                print(posts)
+            case .failure(let error):
+                print("failure: \(error.localizedDescription)")
+            }
+        }
+    }
 }

--- a/Netable/NetableExample/Request/GraphQL/UpdatePostMutation.graphql
+++ b/Netable/NetableExample/Request/GraphQL/UpdatePostMutation.graphql
@@ -1,0 +1,6 @@
+mutation UpdatePost($input: UpdatePostInput!) {
+    updatePost(input: $input) {
+        title
+        content
+    }
+}

--- a/Netable/NetableExample/Request/GraphQL/UpdatePostMutation.swift
+++ b/Netable/NetableExample/Request/GraphQL/UpdatePostMutation.swift
@@ -1,5 +1,5 @@
 //
-//  UpdateFilmMutation.swift
+//  UpdatePostMutation.swift
 //  NetableExample
 //
 //  Created by Brendan on 2022-09-12.
@@ -9,17 +9,17 @@
 import Foundation
 import Netable
 
-struct UpdateFilmMutationInput: Codable {
+struct UpdatePostMutationInput: Codable {
     let id: String
     let title: String
 }
 
-struct UpdateFilmMutation: GraphQLMutation {
-    typealias Input = UpdateFilmMutationInput
+struct UpdatePostMutation: GraphQLMutation {
+    typealias Input = UpdatePostMutationInput
 
     typealias RawResource = Bool
 
-    var input: UpdateFilmMutationInput
+    var input: UpdatePostMutationInput
 
     var source = GraphQLQuerySource.autoResource
 }

--- a/Netable/NetableExample/ViewController/GraphQLViewController.swift
+++ b/Netable/NetableExample/ViewController/GraphQLViewController.swift
@@ -24,6 +24,9 @@ class GraphQLViewController: UITableViewController {
         super.viewWillAppear(animated)
 
         GraphQLRepository.shared.getPosts()
+
+        /// This doesn't actually do anything, but serves as an example of a mutation
+        GraphQLRepository.shared.updatePost(id: "1", title: "A new title")
     }
 
     private func bindRepository() {


### PR DESCRIPTION
I may have merged #97 a little early, I missed some feedback @sakuraehikaru had provided highlighting concerns with the encoding for mutation inputs.

After looking at the code some more, I think we can actually simplify things further as the input is just JSON encoded to a string.

Also fixes the example mutation to match the proper naming, etc for other requests.