### PR TITLE
[102] Small logging improvements

### DIFF
--- a/Netable/Netable/LogDestination.swift
+++ b/Netable/Netable/LogDestination.swift
@@ -54,14 +54,17 @@ public enum LogEvent: CustomDebugStringConvertible {
             return "Started \(request.method.rawValue) request... URL: \(request.urlString) Headers: \(request.headers)"
         case .requestBody(let body):
             return "Body: \(body)"
-        case .requestSuccess(let request, _, let statusCode, let responseData, let finalizedResult):
-            return "Request (\(request.urlString)) completed with status code \(statusCode) Data: \(responseData ?? Data()) Finalized data: \(String(describing: finalizedResult))"
+        case .requestSuccess(let request, _, let statusCode, _, _):
+            return "Request (\(request.urlString)) completed with status code \(statusCode)."
         case .requestRetrying(let request, _, let error):
             return "Request (\(request.urlString)) retrying: \(error.localizedDescription)"
         case .requestFailed(let request, _, let error):
             switch error {
             case .httpError(let statusCode, let data):
-                return "Request (\(request.urlString)) failed with status code \(statusCode) Data: \(data ?? Data())"
+                if let data = data, let dataString = String(data: data, encoding: .utf8) {
+                    return "Request (\(request.urlString)) failed with status code \(statusCode), \(dataString)"
+                }
+                fallthrough
             default:
                 return "Request (\(request.urlString)) failed: \(error.localizedDescription)"
             }

--- a/Netable/NetableExample/Repository/PostRepository.swift
+++ b/Netable/NetableExample/Repository/PostRepository.swift
@@ -13,7 +13,7 @@ class PostRepository {
     static var shared = PostRepository()
 
     /// If we aren't concerned with logging results from a particular instance, pass in the EmptyLogDestination as the logDestination
-    private let netable = Netable(baseURL: URL(string: "http://localhost:8080/posts/")!)
+    private let netable = Netable(baseURL: URL(string: "http://localhost:8080/posts/")!, logDestination: EmptyLogDestination())
 
     var posts: CurrentValueSubject<[Post], Never>
     var cancellables = [AnyCancellable]()

--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ struct GetUserRequest: Request {
 
 ```
 
+#### Logging
+
+By default, Netable will log a fair amount of detail for outgoing requests, using the `DefaultLogDestination`
+
+You can customize this when you create your Netable object by passing in a new log destination that conforms to the provided `LogDestination` protocol. See the example project's [CustomLogDestination](https://github.com/steamclock/netable/blob/master/Netable/NetableExample/Helpers/CustomLogDestination.swift) for an example of this in action.
+
+For convenience, we provide an `EmptyLogDestination` if you would prefer to silence all logs from Netable. See [PostRepository.swift](https://github.com/steamclock/netable/blob/master/Netable/NetableExample/Repository/PostRepository.swift) for an example of this in action.
+
 ### Handling Errors
 
 In addition to handling errors locally through the `completion` callback provided by `request()`,  we provide two ways to handle errors globally. These can be useful for doing things like presenting errors in the UI for common error cases across multiple requests, or catching things like failed authentication requests to clear a stored user.


### PR DESCRIPTION
Some small improvements to logging:
- Don't print the `FinalizedData` returned by a request. This is super spammy and probably not as useful as we'd like. I think if we want to support this down the road, a more verbose log destination would be a good approach.
- Add some info to the README referencing examples for the log destinations and how to swap them out