### PR TITLE
Add support for partially decoding arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] 14-12-22
+- [104] Add support for partially decoding arrays through new `arrayDecodingStrategy` parameter on `Request`.
+- [106] Fix `RetryConfiguration` not being marked as `Sendable`.
+
+
 ## [2.0.0] 18-11-22
 - [77] Rework networking to use async/await by default.
 - [96] Add support + documentation for basic GraphQL requests.
+
 
 ## [1.0.0] 12-9-21
 ### Added
@@ -18,18 +24,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [76] Add an option to set json en/decoding strategies in the Netable config constructor in addition to per-request.
 - [79] Add `requestFailedDelegate` and `requestFailedPublisher` to users to handle errors globally in addition to in `request` completion callbacks. Bumps minimum iOS version to 13.0.
 
+
 ## [0.10.3] - 12-01-21
 ### Changed
 - Fixed an issue with logging successful requests that was preventing finalized data from being printed properly.
 - Fixed a couple small tpyos.
 
+
 ## [0.10.2] - 10-08-20
 ### Added
 - Added support for `DELETE` requests.
 
+
 ## [0.10.1] - 16-07-20
 ### Changed
 - Fixed some properties in the new logging not being marked as "public".
+
 
 ## [0.10.0] - 16-07-20
 ### Added

--- a/Netable/Netable.xcodeproj/project.pbxproj
+++ b/Netable/Netable.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		C692789D26F147FC00917E65 /* GetUserDetailsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C692789C26F147FC00917E65 /* GetUserDetailsRequest.swift */; };
 		C6953F42241A95830044D278 /* LogDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6953F41241A95830044D278 /* LogDestination.swift */; };
 		C6A455EE2912D77600C1C20E /* ErrorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6A455ED2912D77600C1C20E /* ErrorService.swift */; };
+		C6DA3354293822230076F693 /* LossyArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DA3353293822230076F693 /* LossyArray.swift */; };
 		C6F4CFB026D582E8004E6BB8 /* RequestFailedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F4CFAF26D582E8004E6BB8 /* RequestFailedDelegate.swift */; };
 		C6F4CFB626D598B3004E6BB8 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = C6F4CFB526D598B3004E6BB8 /* README.md */; };
 /* End PBXBuildFile section */
@@ -166,6 +167,7 @@
 		C692789C26F147FC00917E65 /* GetUserDetailsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetUserDetailsRequest.swift; sourceTree = "<group>"; };
 		C6953F41241A95830044D278 /* LogDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogDestination.swift; sourceTree = "<group>"; };
 		C6A455ED2912D77600C1C20E /* ErrorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorService.swift; sourceTree = "<group>"; };
+		C6DA3353293822230076F693 /* LossyArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LossyArray.swift; sourceTree = "<group>"; };
 		C6F4CFAF26D582E8004E6BB8 /* RequestFailedDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestFailedDelegate.swift; sourceTree = "<group>"; };
 		C6F4CFB526D598B3004E6BB8 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../../README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -245,6 +247,7 @@
 				B8C928A223E9FBEC00DB2B37 /* HTTPMethod.swift */,
 				B8C9288423E9F68000DB2B37 /* Info.plist */,
 				C6953F41241A95830044D278 /* LogDestination.swift */,
+				C6DA3353293822230076F693 /* LossyArray.swift */,
 				B8C9288323E9F68000DB2B37 /* Netable.h */,
 				B8C928A823E9FDCC00DB2B37 /* Netable.swift */,
 				C6F4CFB526D598B3004E6BB8 /* README.md */,
@@ -592,6 +595,7 @@
 				B8C9289F23E9FB1500DB2B37 /* URLRequest+EncodeParameters.swift in Sources */,
 				C61DC6FC28CFDF3F0089E912 /* GraphQLRequest.swift in Sources */,
 				B8C928A123E9FBA100DB2B37 /* Request.swift in Sources */,
+				C6DA3354293822230076F693 /* LossyArray.swift in Sources */,
 				C65289F526D01829009D486B /* Config.swift in Sources */,
 				C639674D28E4F4CD00ADAE3E /* Netable+Equatable.swift in Sources */,
 				C6953F42241A95830044D278 /* LogDestination.swift in Sources */,
@@ -663,6 +667,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.NetableExample;
 				PRODUCT_NAME = NetableExample;
 				SUPPORTS_MACCATALYST = YES;
+				SWIFT_STRICT_CONCURRENCY = minimal;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -685,6 +690,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.NetableExample;
 				PRODUCT_NAME = NetableExample;
 				SUPPORTS_MACCATALYST = YES;
+				SWIFT_STRICT_CONCURRENCY = minimal;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -837,6 +843,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = minimal;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -866,6 +873,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = YES;
+				SWIFT_STRICT_CONCURRENCY = minimal;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/Netable/Netable.xcodeproj/project.pbxproj
+++ b/Netable/Netable.xcodeproj/project.pbxproj
@@ -667,7 +667,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.NetableExample;
 				PRODUCT_NAME = NetableExample;
 				SUPPORTS_MACCATALYST = YES;
-				SWIFT_STRICT_CONCURRENCY = minimal;
+				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -690,7 +690,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.NetableExample;
 				PRODUCT_NAME = NetableExample;
 				SUPPORTS_MACCATALYST = YES;
-				SWIFT_STRICT_CONCURRENCY = minimal;
+				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/Netable/Netable.xcodeproj/project.pbxproj
+++ b/Netable/Netable.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		C639674D28E4F4CD00ADAE3E /* Netable+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C639674C28E4F4CD00ADAE3E /* Netable+Equatable.swift */; };
 		C639674F28E4F58100ADAE3E /* String+FullyQualifiedURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = C639674E28E4F58100ADAE3E /* String+FullyQualifiedURL.swift */; };
 		C639675128E5F89D00ADAE3E /* Netable+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = C639675028E5F89D00ADAE3E /* Netable+Error.swift */; };
+		C64ADA47293F9ED900695444 /* ArrayDecodeStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64ADA46293F9ED900695444 /* ArrayDecodeStrategy.swift */; };
 		C64EAB6926F2828E0093850A /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64EAB6826F2828E0093850A /* Post.swift */; };
 		C64EAB6B26F283440093850A /* GetPostsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64EAB6A26F283440093850A /* GetPostsRequest.swift */; };
 		C64EAB6D26F29AFD0093850A /* UnauthorizedRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64EAB6C26F29AFD0093850A /* UnauthorizedRequest.swift */; };
@@ -137,6 +138,7 @@
 		C639674C28E4F4CD00ADAE3E /* Netable+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Netable+Equatable.swift"; sourceTree = "<group>"; };
 		C639674E28E4F58100ADAE3E /* String+FullyQualifiedURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+FullyQualifiedURL.swift"; sourceTree = "<group>"; };
 		C639675028E5F89D00ADAE3E /* Netable+Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Netable+Error.swift"; sourceTree = "<group>"; };
+		C64ADA46293F9ED900695444 /* ArrayDecodeStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayDecodeStrategy.swift; sourceTree = "<group>"; };
 		C64EAB6826F2828E0093850A /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
 		C64EAB6A26F283440093850A /* GetPostsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPostsRequest.swift; sourceTree = "<group>"; };
 		C64EAB6C26F29AFD0093850A /* UnauthorizedRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnauthorizedRequest.swift; sourceTree = "<group>"; };
@@ -285,9 +287,10 @@
 		C639674B28E4F4BF00ADAE3E /* Helper */ = {
 			isa = PBXGroup;
 			children = (
+				C64ADA46293F9ED900695444 /* ArrayDecodeStrategy.swift */,
 				C639674C28E4F4CD00ADAE3E /* Netable+Equatable.swift */,
-				C639674E28E4F58100ADAE3E /* String+FullyQualifiedURL.swift */,
 				C639675028E5F89D00ADAE3E /* Netable+Error.swift */,
+				C639674E28E4F58100ADAE3E /* String+FullyQualifiedURL.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -599,6 +602,7 @@
 				C65289F526D01829009D486B /* Config.swift in Sources */,
 				C639674D28E4F4CD00ADAE3E /* Netable+Equatable.swift in Sources */,
 				C6953F42241A95830044D278 /* LogDestination.swift in Sources */,
+				C64ADA47293F9ED900695444 /* ArrayDecodeStrategy.swift in Sources */,
 				B8C9289D23E9FA0E00DB2B37 /* Error.swift in Sources */,
 				C639674F28E4F58100ADAE3E /* String+FullyQualifiedURL.swift in Sources */,
 				B8C928A323E9FBEC00DB2B37 /* HTTPMethod.swift in Sources */,

--- a/Netable/Netable/Helper/ArrayDecodeStrategy.swift
+++ b/Netable/Netable/Helper/ArrayDecodeStrategy.swift
@@ -1,0 +1,20 @@
+//
+//  ArrayDecodeStrategy.swift
+//  Netable
+//
+//  Created by Brendan on 2022-12-06.
+//  Copyright © 2022 Steamclock Software. All rights reserved.
+//
+
+import Foundation
+
+/// Strategy to use when decoding top-level arrays of values
+/// By default, if you try to decode an array objects and one of the objects fails to decode, the entire array fails to decode.
+/// Instead, this allows you to partially decode arrays and only return the well-formed elements.
+/// For lossy decoding nested arrays, we recommend checking out [Better Codable](https://github.com/marksands/BetterCodable).
+public enum ArrayDecodeStrategy {
+    /// If any element of the array fails to decode, the whole array fails.
+    case standard
+    /// Decode the array, omitting any elements that fail to decode.
+    case lossy
+}

--- a/Netable/Netable/LossyArray.swift
+++ b/Netable/Netable/LossyArray.swift
@@ -10,23 +10,28 @@ import Foundation
 
 /// Adapted from https://stackoverflow.com/a/46369152
 
-/// Decodable a non-optional item into an optional element.
-public struct FailableDecodable<Element: Decodable>: Decodable {
-    public var element: Element?
+/// Array container that allows for partial decoding of elements.
+/// If an element of the array fails to decode, it will be omitted rather than the rest of the array failing to decode.
+public struct LossyArray<Element> {
+    /// All elements of the array that decoded successfully.
+    public var elements: [Element]
 
-    /// Decode an element and set it to `nil` if decoding fails.
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        element = try? container.decode(Element.self)
+    public init(elements: [Element]) {
+        self.elements = elements
     }
 }
 
-/// Array container that allows for partial decoding of elements.
-/// If an element of the array fails to decode, it will be omitted rather than the rest of the array failing to decode.
-public struct LossyArray<Element: Decodable>: Decodable {
+extension LossyArray: Decodable where Element: Decodable {
+    /// Decode non-optional item into an optional element.
+    public struct FailableDecodable<Element: Decodable>: Decodable {
+        public var element: Element?
 
-    /// All elements of the array that decoded successfully.
-    public let elements: [Element]
+        /// Decode an element and set it to `nil` if decoding fails.
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            element = try? container.decode(Element.self)
+        }
+    }
 
     /// Attempt to decode the contents of an array, omitting any results that fail to decode.
     public init(from decoder: Decoder) throws {

--- a/Netable/Netable/LossyArray.swift
+++ b/Netable/Netable/LossyArray.swift
@@ -22,8 +22,9 @@ public struct FailableDecodable<Element: Decodable>: Decodable {
 }
 
 /// Array container that allows for partial decoding of elements.
-/// If an element of the array fails to decode, it will be ommited rather than the rest of the array failing to decode.
+/// If an element of the array fails to decode, it will be omitted rather than the rest of the array failing to decode.
 public struct LossyArray<Element: Decodable>: Decodable {
+
     /// All elements of the array that decoded successfully.
     public let elements: [Element]
 

--- a/Netable/Netable/LossyArray.swift
+++ b/Netable/Netable/LossyArray.swift
@@ -1,0 +1,40 @@
+//
+//  LossyArray.swift
+//  Netable
+//
+//  Created by Brendan on 2022-11-30.
+//  Copyright © 2022 Steamclock Software. All rights reserved.
+//
+
+import Foundation
+
+/// Adapted from https://stackoverflow.com/a/46369152
+
+/// Decodable a non-optional item into an optional element.
+public struct FailableDecodable<Element: Decodable>: Decodable {
+    public var element: Element?
+
+    /// Decode an element and set it to `nil` if decoding fails.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        element = try? container.decode(Element.self)
+    }
+}
+
+/// Array container that allows for partial decoding of elements.
+/// If an element of the array fails to decode, it will be ommited rather than the rest of the array failing to decode.
+public struct LossyArray<Element: Decodable>: Decodable {
+    /// All elements of the array that decoded successfully.
+    public let elements: [Element]
+
+    /// Attempt to decode the contents of an array, omitting any results that fail to decode.
+    public init(from decoder: Decoder) throws {
+        var elements = [Element?]()
+        var container = try decoder.unkeyedContainer()
+        while !container.isAtEnd {
+            let item = try container.decode(FailableDecodable<Element>.self).element
+            elements.append(item)
+        }
+        self.elements = elements.compactMap { $0 }
+    }
+}

--- a/Netable/Netable/Request.swift
+++ b/Netable/Netable/Request.swift
@@ -173,15 +173,6 @@ public extension Request where RawResource == SmartUnwrap<FinalResource> {
     }
 }
 
-public extension Request where RawResource == SmartUnwrap<LossyArray<FinalResource>> {
-    func finalize(raw: RawResource) async throws -> FinalResource {
-        guard let finalized = raw.decodedType.elements as? Self.FinalResource else {
-            throw NetableError.resourceExtractionError("Failed to unwrap LossyArray elements")
-        }
-        return finalized
-    }
-}
-
 public extension Request where RawResource: Decodable, FallbackResource: Decodable {
     func decode(_ data: Data?, defaultDecodingStrategy: JSONDecoder.KeyDecodingStrategy) async throws -> RawResource {
         let decoder = JSONDecoder()

--- a/Netable/Netable/Request.swift
+++ b/Netable/Netable/Request.swift
@@ -175,7 +175,10 @@ public extension Request where RawResource == SmartUnwrap<FinalResource> {
 
 public extension Request where RawResource == SmartUnwrap<LossyArray<FinalResource>> {
     func finalize(raw: RawResource) async throws -> FinalResource {
-        return raw.decodedType.elements as! Self.FinalResource
+        guard let finalized = raw.decodedType.elements as? Self.FinalResource else {
+            throw NetableError.resourceExtractionError("Failed to unwrap LossyArray elements")
+        }
+        return finalized
     }
 }
 

--- a/Netable/Netable/Request.swift
+++ b/Netable/Netable/Request.swift
@@ -125,8 +125,7 @@ public extension Request where RawResource: Decodable {
                 let raw = try decoder.decode(RawResource.self, from: Empty.data)
                 return raw
             } else if let data = data {
-                let raw = try decoder.decode(RawResource.self, from: data)
-                return raw
+                return try decoder.decode(RawResource.self, from: data)
             }
         } catch {
             throw NetableError.decodingError(error, data)
@@ -171,6 +170,12 @@ public extension Request where RawResource == SmartUnwrap<FinalResource> {
     func finalize(raw: RawResource) async throws -> FinalResource {
         let unwrapped = raw as SmartUnwrap<FinalResource>
         return unwrapped.decodedType
+    }
+}
+
+public extension Request where RawResource == SmartUnwrap<LossyArray<FinalResource>> {
+    func finalize(raw: RawResource) async throws -> FinalResource {
+        return raw.decodedType.elements as! Self.FinalResource
     }
 }
 

--- a/Netable/Netable/Request.swift
+++ b/Netable/Netable/Request.swift
@@ -203,5 +203,3 @@ public extension Request where RawResource: Decodable, FallbackResource: Decodab
 public struct Empty: Codable {
     public static let data = "{}".data(using: .utf8)!
 }
-
-

--- a/Netable/Netable/RetryConfiguration.swift
+++ b/Netable/Netable/RetryConfiguration.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-public struct RetryConfiguration {
+public struct RetryConfiguration: Sendable {
     /// Specify types of networking errors to retry
-    public enum Errors {
+    public enum Errors: Sendable {
         /// No retries will happen
         case none
 
@@ -21,7 +21,7 @@ public struct RetryConfiguration {
         case transport
 
         /// Test the errors with a user supplied closure. Custom errors are limited in the same way that ".all" is, there are certain types of errors (request formatting errors, cancellation, network timeouts) that this will NOT be called for and there is no option to retry. Note: will be called on a background thread so closure must be thread safe
-        case custom(retryTest: (NetableError) -> Bool)
+        case custom(retryTest: @Sendable (NetableError) -> Bool)
 
         internal func shouldRetry(_ error: NetableError) -> Bool {
             switch self {

--- a/Netable/Netable/SmartUnwrap.swift
+++ b/Netable/Netable/SmartUnwrap.swift
@@ -27,6 +27,10 @@ public struct SmartUnwrap<T: Decodable>: Decodable {
         }
     }
 
+    public init(decodedType: T) {
+        self.decodedType = decodedType
+    }
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DynamicCodingKeys.self)
         let smartUnwrapKey = decoder.userInfo[.smartUnwrapKey] as? String

--- a/Netable/NetableExample/Repository/PostRepository.swift
+++ b/Netable/NetableExample/Repository/PostRepository.swift
@@ -47,6 +47,7 @@ class PostRepository {
         Task { @MainActor in
             do {
                 let posts = try await netable.request(GetPostsRequest())
+                print(posts)
                 self.posts.send(posts)
             } catch {
                 print(error)

--- a/Netable/NetableExample/Repository/PostRepository.swift
+++ b/Netable/NetableExample/Repository/PostRepository.swift
@@ -46,7 +46,7 @@ class PostRepository {
     func getPosts() {
         Task { @MainActor in
             do {
-                let posts = try await netable.request(GetPostsRequest())
+                let posts = try await self.netable.request(GetPostsRequest())
                 print(posts)
                 self.posts.send(posts)
             } catch {

--- a/Netable/NetableExample/Request/GetPostsRequest.swift
+++ b/Netable/NetableExample/Request/GetPostsRequest.swift
@@ -10,7 +10,7 @@ import Netable
 
 struct GetPostsRequest: Request {
     typealias Parameters = Empty
-    typealias RawResource = SmartUnwrap<[Post]>
+    typealias RawResource = SmartUnwrap<LossyArray<Post>>
     typealias FinalResource = [Post]
 
     var method = HTTPMethod.get
@@ -19,5 +19,9 @@ struct GetPostsRequest: Request {
 
     var unredactedParameterKeys: Set<String> {
         ["title", "content"]
+    }
+
+    func finalize(raw: SmartUnwrap<LossyArray<Post>>) async throws -> [Post] {
+        raw.decodedType.elements
     }
 }

--- a/Netable/NetableExample/Request/GetPostsRequest.swift
+++ b/Netable/NetableExample/Request/GetPostsRequest.swift
@@ -10,8 +10,12 @@ import Netable
 
 struct GetPostsRequest: Request {
     typealias Parameters = Empty
-    typealias RawResource = SmartUnwrap<LossyArray<Post>>
+    typealias RawResource = Result
     typealias FinalResource = [Post]
+
+    struct Result: Decodable {
+        let posts: LossyArray<Post>
+    }
 
     var method = HTTPMethod.get
 
@@ -21,8 +25,7 @@ struct GetPostsRequest: Request {
         ["title", "content"]
     }
 
-    func finalize(raw: SmartUnwrap<LossyArray<Post>>) async throws -> [Post] {
-        raw.decodedType.elements
+    func finalize(raw: Result) async throws -> [Post] {
+        raw.posts.elements
     }
-
 }

--- a/Netable/NetableExample/Request/GetPostsRequest.swift
+++ b/Netable/NetableExample/Request/GetPostsRequest.swift
@@ -10,7 +10,8 @@ import Netable
 
 struct GetPostsRequest: Request {
     typealias Parameters = Empty
-    typealias RawResource = [Post]
+    typealias RawResource = SmartUnwrap<[Post]>
+    typealias FinalResource = [Post]
 
     var method = HTTPMethod.get
 

--- a/Netable/NetableExample/Request/GetPostsRequest.swift
+++ b/Netable/NetableExample/Request/GetPostsRequest.swift
@@ -24,4 +24,5 @@ struct GetPostsRequest: Request {
     func finalize(raw: SmartUnwrap<LossyArray<Post>>) async throws -> [Post] {
         raw.decodedType.elements
     }
+
 }

--- a/Netable/NetableExample/Request/GetPostsRequest.swift
+++ b/Netable/NetableExample/Request/GetPostsRequest.swift
@@ -10,22 +10,15 @@ import Netable
 
 struct GetPostsRequest: Request {
     typealias Parameters = Empty
-    typealias RawResource = Result
-    typealias FinalResource = [Post]
-
-    struct Result: Decodable {
-        let posts: LossyArray<Post>
-    }
+    typealias RawResource = [Post]
 
     var method = HTTPMethod.get
 
     var path = "all"
 
+    var arrayDecodeStrategy: ArrayDecodeStrategy { .lossy }
+
     var unredactedParameterKeys: Set<String> {
         ["title", "content"]
-    }
-
-    func finalize(raw: Result) async throws -> [Post] {
-        raw.posts.elements
     }
 }

--- a/Netable/NetableExample/Resources/JsonResponse/posts.json
+++ b/Netable/NetableExample/Resources/JsonResponse/posts.json
@@ -1,8 +1,7 @@
 {
     "posts": [
         {
-            "title": "first post",
-            "content": "em ipsum dolor sit amet, consectetur adipiscing elit. Proin in mattis magna. Pellentesque ac tortor nec lectus auctor egestas. Proin erat felis, finibus vitae condimentum at, viverra sed arcu."
+            "title": "first post"
         },
         {
             "title": "second post",

--- a/Netable/NetableExample/Resources/JsonResponse/posts.json
+++ b/Netable/NetableExample/Resources/JsonResponse/posts.json
@@ -1,23 +1,21 @@
-{
-    "posts": [
-        {
-            "title": "first post"
-        },
-        {
-            "title": "second post",
-            "content": "Sed iaculis ut diam sodales molestie. Ut efficitur purus massa, at consectetur tortor sodales ultricies. Donec rhoncus nisi et libero egestas finibus."
-        },
-        {
-            "title": "third post",
-            "content": "Fusce placerat velit sapien, eu pellentesque magna facilisis vitae. Sed purus diam, congue sed ullamcorper sed, aliquam a justo. Mauris at ipsum rutrum, placerat nunc sit amet, facilisis lorem."
-        },
-        {
-            "title": "fourth post",
-            "content": "Etiam eros turpis, euismod at tincidunt quis, gravida nec augue."
-        },
-        {
-            "title": "fifth post",
-            "content": "Suspendisse vel nibh enim. Ut id semper magna. Sed nec velit orci."
-        },
-    ]
-}
+ [
+    {
+        "title": "first post"
+    },
+    {
+        "title": "second post",
+        "content": "Sed iaculis ut diam sodales molestie. Ut efficitur purus massa, at consectetur tortor sodales ultricies. Donec rhoncus nisi et libero egestas finibus."
+    },
+    {
+        "title": "third post",
+        "content": "Fusce placerat velit sapien, eu pellentesque magna facilisis vitae. Sed purus diam, congue sed ullamcorper sed, aliquam a justo. Mauris at ipsum rutrum, placerat nunc sit amet, facilisis lorem."
+    },
+    {
+        "title": "fourth post",
+        "content": "Etiam eros turpis, euismod at tincidunt quis, gravida nec augue."
+    },
+    {
+        "title": "fifth post",
+        "content": "Suspendisse vel nibh enim. Ut id semper magna. Sed nec velit orci."
+    },
+]

--- a/Netable/NetableExample/Resources/JsonResponse/posts.json
+++ b/Netable/NetableExample/Resources/JsonResponse/posts.json
@@ -1,21 +1,23 @@
- [
-    {
-        "title": "first post"
-    },
-    {
-        "title": "second post",
-        "content": "Sed iaculis ut diam sodales molestie. Ut efficitur purus massa, at consectetur tortor sodales ultricies. Donec rhoncus nisi et libero egestas finibus."
-    },
-    {
-        "title": "third post",
-        "content": "Fusce placerat velit sapien, eu pellentesque magna facilisis vitae. Sed purus diam, congue sed ullamcorper sed, aliquam a justo. Mauris at ipsum rutrum, placerat nunc sit amet, facilisis lorem."
-    },
-    {
-        "title": "fourth post",
-        "content": "Etiam eros turpis, euismod at tincidunt quis, gravida nec augue."
-    },
-    {
-        "title": "fifth post",
-        "content": "Suspendisse vel nibh enim. Ut id semper magna. Sed nec velit orci."
-    },
-]
+{
+    "posts":[
+        {
+            "title": "first post"
+        },
+        {
+            "title": "second post",
+            "content": "Sed iaculis ut diam sodales molestie. Ut efficitur purus massa, at consectetur tortor sodales ultricies. Donec rhoncus nisi et libero egestas finibus."
+        },
+        {
+            "title": "third post",
+            "content": "Fusce placerat velit sapien, eu pellentesque magna facilisis vitae. Sed purus diam, congue sed ullamcorper sed, aliquam a justo. Mauris at ipsum rutrum, placerat nunc sit amet, facilisis lorem."
+        },
+        {
+            "title": "fourth post",
+            "content": "Etiam eros turpis, euismod at tincidunt quis, gravida nec augue."
+        },
+        {
+            "title": "fifth post",
+            "content": "Suspendisse vel nibh enim. Ut id semper magna. Sed nec velit orci."
+        },
+    ]
+}

--- a/Netable/NetableExample/Service/ExampleNetworkService.swift
+++ b/Netable/NetableExample/Service/ExampleNetworkService.swift
@@ -54,10 +54,17 @@ class ExampleNetworkService {
 
     private func loadJson(from path: String) -> HttpResponseBody {
         guard let path = Bundle.main.path(forResource: path, ofType: "json"),
-                let data = try? Data(contentsOf: URL(fileURLWithPath: path), options: .mappedIfSafe),
-                let jsonResult = try? JSONSerialization.jsonObject(with: data, options: .mutableLeaves),
-                let jsonResult = jsonResult as? Dictionary<String, AnyObject> else {
+              let data = try? Data(contentsOf: URL(fileURLWithPath: path), options: .mappedIfSafe),
+              let jsonResult = try? JSONSerialization.jsonObject(with: data, options: .mutableLeaves) else {
             fatalError("Failed to load response JSON for: \(path)")
+        }
+
+        if let result = jsonResult as? Dictionary<String, AnyObject> {
+            return .json(result)
+        }
+
+        if let result = jsonResult as? [Dictionary<String, AnyObject>] {
+            return .json(result)
         }
 
         return .json(jsonResult)

--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@ Modern apps interact with a lot of different APIs. Netable makes that easier by 
 
 - [Features](#features)
 - [Usage](#usage)
+    - [Standard Usage](#standard-usage)
+    - [Resource Extraction](#resource-extraction)
+    - [Handling Errors](#handling-errors)
+    - [GraphQL Support](#graphql-support)
 - [Example](#example)
-- [Requirements](#requirements)
+   - [Full Documentation](#full-documentation)
 - [Installation](#installation)
+   - [Requirements](#requirements)
+   - [Supporting Earlier Versions][#supporting-earlier-versions-of-ios]
 - [License](#license)
 
 ## Features
@@ -52,7 +58,7 @@ struct GetCatImages: Request {
 }
 ```
 
-### Make your request using `async`/`await` and handle the result:
+#### Make your request using `async`/`await` and handle the result:
 
 ```swift
 Task {
@@ -82,7 +88,7 @@ Task {
 }
 ```
 
-### Making a request with Combine
+#### Making a request with Combine
 
 ```swift
 netable.request(GetCatImages())
@@ -113,7 +119,7 @@ netable.request(GetCatImages())
     }.store(in: &cancellables)
 ```
 
-### Or, if you prefer good old fashioned callbacks
+#### Or, if you prefer good old fashioned callbacks
 
 ```swift
 netable.request(GetCatImages()) { result in
@@ -236,6 +242,12 @@ struct GetUserRequest: Request {
 
 ```
 
+#### Partially Decoding Arrays
+
+Sometimes, when decoding an array of objects, you may not want to fail the entire request if some of those objects fail to decode.
+
+To do this, you can wrap your `RawResource` in the `LossyArray` type, the in your `finalize` function, grab the `LossyArray`'s `elements` to unwrap your partially decoded array.
+
 ### Handling Errors
 
 In addition to handling errors locally that are thrown, or returned through `Result` objects, we provide two ways to handle errors globally. These can be useful for doing things like presenting errors in the UI for common error cases across multiple requests, or catching things like failed authentication requests to clear a stored user.
@@ -276,7 +288,7 @@ Sometimes, you may want to specify a backup type to try and decode your response
 
 See [FallbackDecoderViewController](https://github.com/steamclock/netable/blob/master/Netable/NetableExample/Request/VersionCheckRequest.swift) in the Example project for a more detailed example.
 
-#### GraphQL Support
+### GraphQL Support
 
 While you can technically use `Netable` to manage GraphQL queries right out of the box, we've added a helper protocol to make your life a little bit easier, called `GraphQLRequest`.
 
@@ -284,19 +296,19 @@ You can see a detailed example in the example project, but note that by default 
 
 We recommend using a tool like [Postman](https://www.postman.com/) to document and test your queries. Also note that currently, shared fragments are not supported.
 
+## Example
+
 ### Full Documentation
 
 [In-depth documentation](https://steamclock.github.io/netable/) is provided through Jazzy and GitHub Pages.  
 
-## Example
+## Installation
 
-## Requirements
+### Requirements
 
 - iOS 15.0+
 - MacOS 10.15+
 - Xcode 11.0+
-
-## Installation
 
 Netable is available through **[Swift Package Manager](https://swift.org/package-manager/)**. To install it, follow these steps:
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,9 @@ struct GetUserRequest: Request {
 
 Sometimes, when decoding an array of objects, you may not want to fail the entire request if some of those objects fail to decode.
 
-To do this, you can wrap your `RawResource` in the `LossyArray` type, the in your `finalize` function, grab the `LossyArray`'s `elements` to unwrap your partially decoded array.
+To do this, you can set your Request's `arrayDecodeStrategy` to `.lossy` to return any elements that succeed to decode.
+
+Not that this will only work if your `RawResource: Sequence` or `RawResource: SmartUnwrap<Sequence>`. For better support of decoding nested, lossy, arrays we recommend checking out [Better Codable](https://github.com/marksands/BetterCodable)  
 
 ### Handling Errors
 


### PR DESCRIPTION
For #106, #104

This PR adds a new convenience container called `LossyArray` that's meant to help with partially decoding arrays of objects, where you don't want to fail the whole request if one of the objects fails to decode.

I'm still working on getting some convenience `finalizes` together, but generics are hard 😵 In the meantime, I thought it would be good to get your feedback on how this seems.


Also fixes RetryConfiguration not being marked as Sendable and reformats the README to be a little more accessible