### PR TITLE
Changed Request encoding/decoding to non-optional with default param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+- [#108] Changed Request json encoding/decoding to non-optional with default parameters.
+
 ## [2.1.0] 14-12-22
 - [104] Add support for partially decoding arrays through new `arrayDecodingStrategy` parameter on `Request`.
 - [106] Fix `RetryConfiguration` not being marked as `Sendable`.

--- a/Netable/Netable/Request.swift
+++ b/Netable/Netable/Request.swift
@@ -49,10 +49,10 @@ public protocol Request: Sendable {
     var unredactedParameterKeys: Set<String> { get }
 
     /// Optional: The key decoding strategy to be used when decoding return JSON. Default is `.useDefaultKeys`.
-    var jsonKeyDecodingStrategy: JSONDecoder.KeyDecodingStrategy? { get }
+    var jsonKeyDecodingStrategy: JSONDecoder.KeyDecodingStrategy { get }
 
     /// Optional: The key encoding strategy to be used when encoding JSON parameters. Default is `.useDefaultKeys`.
-    var jsonKeyEncodingStrategy: JSONEncoder.KeyEncodingStrategy? { get }
+    var jsonKeyEncodingStrategy: JSONEncoder.KeyEncodingStrategy { get }
 
     /// Optional: The method to decode Data into your RawResource
     func decode(_ data: Data?, defaultDecodingStrategy: JSONDecoder.KeyDecodingStrategy) async throws -> RawResource
@@ -97,13 +97,13 @@ public extension Request {
     }
 
     /// Set the default key decoding strategy.
-    var jsonKeyDecodingStrategy: JSONDecoder.KeyDecodingStrategy? {
-        return nil
+    var jsonKeyDecodingStrategy: JSONDecoder.KeyDecodingStrategy {
+        return .useDefaultKeys
     }
 
     /// Set the default key encoding strategy.
-    var jsonKeyEncodingStrategy: JSONEncoder.KeyEncodingStrategy? {
-        return nil
+    var jsonKeyEncodingStrategy: JSONEncoder.KeyEncodingStrategy {
+        return .useDefaultKeys
     }
 }
 


### PR DESCRIPTION
I went ahead and changed both the `jsonKeyDecodingStrategy` and `jsonKeyEncodingStrategy`, making both use the default `KeyDecodingStrategy`, which is `.useDefaultKeys`, as specified in the Foundation docs!

I tested it on the old project and everything builds and decodes correctly.