### PR TITLE
Revert "Changed Request encoding/decoding to non-optional with default param"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## UNRELEASED
-- [#108] Changed Request json encoding/decoding to non-optional with default parameters.
-
 ## [2.1.0] 14-12-22
 - [104] Add support for partially decoding arrays through new `arrayDecodingStrategy` parameter on `Request`.
 - [106] Fix `RetryConfiguration` not being marked as `Sendable`.

--- a/Netable/Netable/Request.swift
+++ b/Netable/Netable/Request.swift
@@ -49,10 +49,10 @@ public protocol Request: Sendable {
     var unredactedParameterKeys: Set<String> { get }
 
     /// Optional: The key decoding strategy to be used when decoding return JSON. Default is `.useDefaultKeys`.
-    var jsonKeyDecodingStrategy: JSONDecoder.KeyDecodingStrategy { get }
+    var jsonKeyDecodingStrategy: JSONDecoder.KeyDecodingStrategy? { get }
 
     /// Optional: The key encoding strategy to be used when encoding JSON parameters. Default is `.useDefaultKeys`.
-    var jsonKeyEncodingStrategy: JSONEncoder.KeyEncodingStrategy { get }
+    var jsonKeyEncodingStrategy: JSONEncoder.KeyEncodingStrategy? { get }
 
     /// Optional: The method to decode Data into your RawResource
     func decode(_ data: Data?, defaultDecodingStrategy: JSONDecoder.KeyDecodingStrategy) async throws -> RawResource
@@ -97,13 +97,13 @@ public extension Request {
     }
 
     /// Set the default key decoding strategy.
-    var jsonKeyDecodingStrategy: JSONDecoder.KeyDecodingStrategy {
-        return .useDefaultKeys
+    var jsonKeyDecodingStrategy: JSONDecoder.KeyDecodingStrategy? {
+        return nil
     }
 
     /// Set the default key encoding strategy.
-    var jsonKeyEncodingStrategy: JSONEncoder.KeyEncodingStrategy {
-        return .useDefaultKeys
+    var jsonKeyEncodingStrategy: JSONEncoder.KeyEncodingStrategy? {
+        return nil
     }
 }
 


### PR DESCRIPTION
Reverts steamclock/netable#109

@brendanlensink I am reverting this because I found a decent issue that comes along with implementing this.

Currently we have two places that we can set encoding/decoding, the request itself or the netable implementation configurations. Currently, we're checking if there is a strategy within the individual request existing and if it doesn't exist, it defaults to the config one, which is set to use default keys. 

Since we removed the optional, this would never happen, which means that config option is rendered useless. 

I think we need to rethink how we want to solve this issue as to not affect the current structure of Config being the base decoding/encoding strategy which is overridden by a requests if it exists! My gut tells me that we are going to want to keep it optional because this structure currently makes a lot of sense, but then I'm unsure how to handle that error we encountered.