### PR TITLE
added jsondecoding/encoding key support for smart unwrap requests

### DIFF
--- a/Netable/Netable/Request.swift
+++ b/Netable/Netable/Request.swift
@@ -197,6 +197,9 @@ public extension Request where
             decoder.userInfo = [
                 .smartUnwrapKey: smartUnwrapKey
             ]
+            decoder.dateDecodingStrategy = .iso8601
+            decoder.keyDecodingStrategy = jsonKeyDecodingStrategy ?? defaultDecodingStrategy
+
 
             guard arrayDecodeStrategy == .lossy else {
                 return try decoder.decode(SmartUnwrap<FinalResource>.self, from: data)
@@ -228,6 +231,9 @@ public extension Request where RawResource == SmartUnwrap<FinalResource> {
             decoder.userInfo = [
                 .smartUnwrapKey: smartUnwrapKey
             ]
+            decoder.dateDecodingStrategy = .iso8601
+            decoder.keyDecodingStrategy = jsonKeyDecodingStrategy ?? defaultDecodingStrategy
+
             let decodedResult = try decoder.decode(SmartUnwrap<FinalResource>.self, from: data)
             return decodedResult
         } catch {


### PR DESCRIPTION
The requests using smart unwrap were missing the addition of the decoding/encoding lines, which meant the request always failed if a user provided a key while also using smart unwrap. I added support in. This is unrelated to Issue #108.