### PR TITLE
Support added to utilize array & iteration methods directly on LossyArray

### DIFF
--- a/Netable/Netable/LossyArray.swift
+++ b/Netable/Netable/LossyArray.swift
@@ -45,7 +45,7 @@ extension LossyArray: Decodable where Element: Decodable {
     }
 }
 
-/// Adapted from: https://kenb.us/lossy-decodable-for-arrays#:~:text=extension%20LossyDecodableArray%3A%20RandomAccessCollection%20%7B
+/// Adapted from: https://kenb.us/lossy-decodable-for-arrays
 /// Gives array method access to LossyArray without needing to access the element within.
 extension LossyArray: RandomAccessCollection {
     public var startIndex: Int { return elements.startIndex }

--- a/Netable/Netable/LossyArray.swift
+++ b/Netable/Netable/LossyArray.swift
@@ -44,3 +44,14 @@ extension LossyArray: Decodable where Element: Decodable {
         self.elements = elements.compactMap { $0 }
     }
 }
+
+/// Adapted from: https://kenb.us/lossy-decodable-for-arrays#:~:text=extension%20LossyDecodableArray%3A%20RandomAccessCollection%20%7B
+/// Gives array method access to LossyArray without needing to access the element within.
+extension LossyArray: RandomAccessCollection {
+    public var startIndex: Int { return elements.startIndex }
+    public var endIndex: Int { return elements.endIndex }
+
+    public subscript(_ index: Int) -> Element {
+        return elements[index]
+    }
+}


### PR DESCRIPTION
With the current way `LossyArray` was set up, we were only able to access the array elements within the `element` var inside of the LossyArray. This meant that if we wanted to use any methods on our Lossy array, you'd need to access `.element`, like so:

```swift
List {
      ForEach(user.loginData.elements, id: \.self) { item in
           Text("Location: \(item.location)")
       }
 }
```

It was a really straightforward fix, only needing to conform LossyArray to `Random Access Collection`. Now, we can use LossyArrays the same way we'd use standard arrays throughout our code, after they've been decoded, like so:

```swift
 List {
      ForEach(user.loginData, id: \.self) { item in
           Text("Location: \(item.location)")
      }
 }
```

You can find even more about this in #113!